### PR TITLE
docs(readme): onboarding steps for PROVABLY_API_KEY + PROVABLY_ORG_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ The SDK reads configuration from environment variables. A typed
 `Provably(api_key=..., org_id=..., ...)` client that replaces these globals is
 planned (issue [#2](https://github.com/ProvablyAI/provably-python-sdk/issues/2)).
 
+#### Getting `PROVABLY_API_KEY` and `PROVABLY_ORG_ID`
+
+1. Sign up at [app.provably.ai](https://app.provably.ai).
+2. Create an organisation. The org id is shown in the URL after creation and is what goes in `PROVABLY_ORG_ID`.
+3. In the left-side menu, go to **Integrations** and create one. The generated key is your `PROVABLY_API_KEY`.
+
+Full product docs: [provably.ai/docs](https://provably.ai/docs).
+
 | Variable | Used by | Required |
 |---|---|---|
 | `PROVABLY_API_KEY` | `initialize_runtime`, integration cache | yes |


### PR DESCRIPTION
## What

Adds a short onboarding subsection under `## Configuration` walking through how to obtain `PROVABLY_API_KEY` and `PROVABLY_ORG_ID`:

1. Sign up at [app.provably.ai](https://app.provably.ai).
2. Create an organisation — the org id is in the post-creation URL.
3. Left-side menu → **Integrations** → create one. The generated key is `PROVABLY_API_KEY`.

Plus a link to [provably.ai/docs](https://provably.ai/docs) for full product documentation.

## Why

The existing env-var table told readers these values were required but not where to source them — first-time users had no obvious path from `pip install` to a working config.