### PR TITLE
Adjust polling intervals and force parameter for reliability

### DIFF
--- a/src/provably/handoff/_preprocess.py
+++ b/src/provably/handoff/_preprocess.py
@@ -85,7 +85,7 @@ def run_preprocess(org_id: str, middleware_id: str, table_id: str) -> None:
     """Kick preprocess for the intercepts table and poll until it completes."""
     path = f"/api/v1/organizations/{org_id}/middlewares/{middleware_id}/tables/{table_id}/preprocess"
     _log.info("preprocess_started")
-    post_json(path, {})
+    post_json(path, {"force": True})
     retried_force = False
     while True:
         status = _preprocess_status(get_json(path))
@@ -99,7 +99,7 @@ def run_preprocess(org_id: str, middleware_id: str, table_id: str) -> None:
             post_json(path, {"force": True})
             retried_force = True
             continue
-        time.sleep(2)
+        time.sleep(0.3)
 
 
 def wait_for_proof_completed(org_id: str, query_id: str, timeout_s: float = 180.0) -> None:
@@ -114,7 +114,7 @@ def wait_for_proof_completed(org_id: str, query_id: str, timeout_s: float = 180.
                 return
             if status == "failed":
                 raise RuntimeError(f"Proof generation failed: {proof}")
-        time.sleep(1.5)
+        time.sleep(0.1)
     raise TimeoutError(f"Proof still not Completed for query {query_id} after {timeout_s}s")
 
 


### PR DESCRIPTION
This PR improves preprocessing and proof completion responsiveness by reducing polling intervals and forcing preprocess execution.

Changes
- run_preprocess now always sends {"force": True} to ensure preprocessing is triggered.
- Reduced preprocess polling interval from 2s to 0.3s.
- Reduced proof completion polling interval from 1.5s to 0.1s for faster status detection.