### PR TITLE
docs(readme): rebrand to SourceryKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Verifiable Data AgentKit
+# SourceryKit
 
 [![status: v0.2](https://img.shields.io/badge/status-v0.2-blue)](CHANGELOG.md)
 [![python: 3.11+](https://img.shields.io/badge/python-3.11+-blue)](pyproject.toml)
 [![license: Proprietary](https://img.shields.io/badge/license-Proprietary-red)](LICENSE.md)
 
-The Python SDK for [Provably](https://provably.ai). Adds a deterministic
+SourceryKit is the Python SDK for [Provably](https://provably.ai). Adds a deterministic
 **eval** layer (verifiable guardrails — distinct from proof _verification_)
 to any Python agent: every outbound HTTP call is recorded, every claim
 handed off to another agent is evaluated against a trusted Provably query


### PR DESCRIPTION
## Summary
- README title: `Verifiable Data AgentKit` → `SourceryKit`
- README intro: lead sentence now introduces SourceryKit as the brand

Scope is intentionally minimal — title + lead only. Generic "the SDK" references, the PyPI distribution name (`provably-sdk`), and repo URLs are left as-is.

## Test plan
- [ ] Render the README on GitHub and confirm the title + first paragraph read correctly.