### PR TITLE
docs: agent-facing landing (AGENTS.md + llms.txt) + onboarding guide + breadcrumbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ agent's claims against what those calls actually returned, so a hallucinated val
 This is the landing page for AI agents. Read the gate below, then follow the breadcrumb to
 the one page you need. Each doc is focused — load only what the task requires.
 
+## Install
+
+```bash
+pip install sourcerykit    # Python 3.12+
+```
+
 ## ⚠️ Gate: one human step during setup
 
 Setup is agent-drivable except one step: account registration triggers an **email
@@ -22,12 +28,6 @@ nothing downstream works.
    the global config and writes the project's `.env`. Re-check with `sourcerykit doctor`.
 
 → **[docs/onboarding.md](docs/onboarding.md)** — the one-time setup (wizard, email verify, DB)
-
-## Install
-
-```bash
-pip install sourcerykit    # Python 3.12+
-```
 
 ## Pick your path
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,9 @@ agent's claims against what those calls actually returned, so a hallucinated val
 This is the landing page for AI agents. Read the gate below, then follow the breadcrumb to
 the one page you need. Each doc is focused — load only what the task requires.
 
-## ⚠️ Gate: one human step during setup
-
-Setup is agent-drivable except one step: account registration triggers an **email
-verification link that only a human can click**. Until it is clicked, login fails and
-nothing downstream works.
-
-→ **[docs/onboarding.md](docs/onboarding.md)** — the full one-time setup (non-interactive
-commands, the verification step, database requirements).
+> [!WARNING]
+> One-time setup has a single human-only step (an email verification click) — everything
+> else is agent-drivable. Details: [docs/onboarding.md](docs/onboarding.md).
 
 ## Pick your path
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,9 @@ You **cannot** finish setup alone. Onboarding creates a Provably account, and th
 sends an **email verification link that only a human can click**. Until that is done, login
 fails and nothing downstream works.
 
-If `.env` does not yet contain `SOURCERYKIT_API_KEY`, `SOURCERYKIT_ORG_ID`, and
-`SOURCERYKIT_POSTGRES_URL`, STOP and ask a human to complete setup.
+Run `sourcerykit doctor` to check. If credentials are missing (API key, org, Postgres URL),
+STOP and ask a human to run `sourcerykit init` — it stores the API key and org in the global
+config and writes the project's `.env`.
 
 → **[docs/onboarding.md](docs/onboarding.md)** — the one-time setup (wizard, email verify, DB)
 
@@ -54,9 +55,13 @@ build_handoff_payload(...)      # compile claims; intercept_agent_id must match 
 evaluate_handoff(payload)       # -> {"outcome": "PASS" | "CAUGHT" | "ERROR", "per_claim": [...]}
 ```
 
-Outcomes: `PASS` = every claim matched the recorded data · `CAUGHT` = a claim did not match
-(or its endpoint was untrusted) · `ERROR` = nothing was verified (e.g. zero claims resolved —
-an empty `per_claim` is always `ERROR`, never a pass).
+Outcomes:
 
-Async throughout — `await` every SDK call. Only `httpx` and `aiohttp` traffic is recorded.
-`action_name` is the join key between the intercepted call and the claim — it must match.
+- `PASS` — every claim matched the recorded data.
+- `CAUGHT` — a claim did not match the recorded data, or its endpoint was not trusted.
+- `ERROR` — nothing was verified (for example, zero claims could be resolved). Verifying
+  zero claims is always `ERROR`, never a pass.
+
+Async throughout — `await` every SDK call. Recorded traffic: `httpx`, `aiohttp`, and
+`requests`. `action_name` is the join key between the intercepted call and the claim — it
+must match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,18 @@ agent's claims against what those calls actually returned, so a hallucinated val
 This is the landing page for AI agents. Read the gate below, then follow the breadcrumb to
 the one page you need. Each doc is focused — load only what the task requires.
 
-## ⚠️ Gate: setup needs a human, once
+## ⚠️ Gate: one human step during setup
 
-You **cannot** finish setup alone. Onboarding creates a Provably account, and the backend
-sends an **email verification link that only a human can click**. Until that is done, login
-fails and nothing downstream works.
+Setup is agent-drivable except one step: account registration triggers an **email
+verification link that only a human can click**. Until it is clicked, login fails and
+nothing downstream works.
 
-Run `sourcerykit doctor` to check. If credentials are missing (API key, org, Postgres URL),
-STOP and ask a human to run `sourcerykit init` — it stores the API key and org in the global
-config and writes the project's `.env`.
+1. `sourcerykit doctor` — if all checks pass, skip this section.
+2. No account yet? `sourcerykit init --register --email <email> --password <password>` —
+   then STOP and ask a human to click the verification link.
+3. Once verified: `sourcerykit init --email <email> --password <password>
+   --postgres-url <postgresql://…> --project-name <name>` — stores the API key and org in
+   the global config and writes the project's `.env`. Re-check with `sourcerykit doctor`.
 
 → **[docs/onboarding.md](docs/onboarding.md)** — the one-time setup (wizard, email verify, DB)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+SourceryKit is the Python SDK for [Provably](https://provably.ai): verifiable guardrails
+for AI agents — it records outbound HTTP calls, enforces endpoint policies, and checks an
+agent's claims against what those calls actually returned, so a hallucinated value is
+**caught** instead of shipped.
+
+This is the landing page for AI agents. Read the gate below, then follow the breadcrumb to
+the one page you need. Each doc is focused — load only what the task requires.
+
+## ⚠️ Gate: setup needs a human, once
+
+You **cannot** finish setup alone. Onboarding creates a Provably account, and the backend
+sends an **email verification link that only a human can click**. Until that is done, login
+fails and nothing downstream works.
+
+If `.env` does not yet contain `SOURCERYKIT_API_KEY`, `SOURCERYKIT_ORG_ID`, and
+`SOURCERYKIT_POSTGRES_URL`, STOP and ask a human to complete setup.
+
+→ **[docs/onboarding.md](docs/onboarding.md)** — the one-time setup (wizard, email verify, DB)
+
+## Install
+
+```bash
+pip install sourcerykit    # Python 3.12+
+```
+
+## Pick your path
+
+| You want to… | Go to |
+|---|---|
+| Set up credentials for the first time | [docs/onboarding.md](docs/onboarding.md) |
+| Run the whole flow end to end | [docs/example.md](docs/example.md) |
+| Copy a runnable agent integration | [cookbooks/openai_agents](cookbooks/openai_agents) · [cookbooks/claude_agent](cookbooks/claude_agent) · [cookbooks/langchain_agent](cookbooks/langchain_agent) |
+| Look up a function, type, or error | [docs/src/api.md](docs/src/api.md) |
+| Use the CLI (`init`, `doctor`, `endpoints`, `trace`) | [docs/cli.md](docs/cli.md) |
+| Record/inspect HTTP calls (`async_intercept_context`) | [docs/intercept.md](docs/intercept.md) |
+| Build the handoff payload + claims, read the verdict | [docs/handoff.md](docs/handoff.md) |
+| Allow-list outbound endpoints | [docs/trusted-endpoints.md](docs/trusted-endpoints.md) |
+| Understand how the pieces fit | [docs/architecture.md](docs/architecture.md) |
+| Migrate from the old `provably` SDK | [docs/migrations/v1_0/v1_0.md](docs/migrations/v1_0/v1_0.md) |
+
+The **cookbooks are the ground truth** for a correct integration: a real agent produces the
+claim as structured output (`SourceryKitAgentResponse`); the claim is never computed by hand.
+
+## The flow at a glance
+
+```
+bootstrap_system()              # init: schema, handshake, HTTP interceptor — call first, once
+insert_trusted_endpoint(url)    # allow-list each outbound endpoint
+async_intercept_context(...)    # wrap the tool's HTTP call — records it
+SourceryKitAgentResponse        # the agent's structured output (reasoning + claimed_values)
+build_handoff_payload(...)      # compile claims; intercept_agent_id must match the agent_id above
+evaluate_handoff(payload)       # -> {"outcome": "PASS" | "CAUGHT" | "ERROR", "per_claim": [...]}
+```
+
+Outcomes: `PASS` = every claim matched the recorded data · `CAUGHT` = a claim did not match
+(or its endpoint was untrusted) · `ERROR` = nothing was verified (e.g. zero claims resolved —
+an empty `per_claim` is always `ERROR`, never a pass).
+
+Async throughout — `await` every SDK call. Only `httpx` and `aiohttp` traffic is recorded.
+`action_name` is the join key between the intercepted call and the claim — it must match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,14 +20,8 @@ Setup is agent-drivable except one step: account registration triggers an **emai
 verification link that only a human can click**. Until it is clicked, login fails and
 nothing downstream works.
 
-1. `sourcerykit doctor` — if all checks pass, skip this section.
-2. No account yet? `sourcerykit init --register --email <email> --password <password>` —
-   then STOP and ask a human to click the verification link.
-3. Once verified: `sourcerykit init --email <email> --password <password>
-   --postgres-url <postgresql://…> --project-name <name>` — stores the API key and org in
-   the global config and writes the project's `.env`. Re-check with `sourcerykit doctor`.
-
-→ **[docs/onboarding.md](docs/onboarding.md)** — the one-time setup (wizard, email verify, DB)
+→ **[docs/onboarding.md](docs/onboarding.md)** — the full one-time setup (non-interactive
+commands, the verification step, database requirements).
 
 ## Pick your path
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,6 @@ agent's claims against what those calls actually returned, so a hallucinated val
 This is the landing page for AI agents. Read the gate below, then follow the breadcrumb to
 the one page you need. Each doc is focused — load only what the task requires.
 
-## Install
-
-```bash
-pip install sourcerykit    # Python 3.12+
-```
-
 ## ⚠️ Gate: one human step during setup
 
 Setup is agent-drivable except one step: account registration triggers an **email

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ for AI agents — it records outbound HTTP calls, enforces endpoint policies, an
 agent's claims against what those calls actually returned, so a hallucinated value is
 **caught** instead of shipped.
 
-This is the landing page for AI agents. Read the gate below, then follow the breadcrumb to
-the one page you need. Each doc is focused — load only what the task requires.
+This is the landing page for AI agents. Follow the breadcrumb to the one page you need.
+Each doc is focused — load only what the task requires.
 
 > [!WARNING]
 > One-time setup has a single human-only step (an email verification click) — everything

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ The wizard will guide you through:
 
 > ⚠️ **IMPORTANT:** The wizard only configures **SOURCERYKIT_*** variables. It does **not** handle third-party LLM provider infrastructure keys, which must still be exported separately.
 
+### Manual configuration (fallback)
+
+Already have credentials, or need to bypass the wizard (CI, containers, debugging)? Environment
+variables override the stored config:
+
+```bash
+export PROVABLY_API_KEY="..."
+export SOURCERYKIT_ORG_ID="..."
+export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
+```
 
 For a full list of CLI commands, check out the [CLI Documentation](https://github.com/ProvablyAI/sourcerykit/blob/main/docs/cli.md) file, or simply run:
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,3 +25,8 @@ SourceryKit intercepts an agent’s outbound HTTP calls, enforces endpoint polic
 - **Evaluator**: Compares agent claims against authoritative records from the Provably backend, returning a deterministic verdict (`PASS`, `CAUGHT`, or `ERROR`). See [handoff](handoff.md).
 
 - **Provably Backend**: The external service acting as the single source of truth for verifying agent claims by generating proofs from the Intercepts table.
+
+---
+
+**Next:** set up and run → [onboarding](onboarding.md) · [example](example.md) ·
+go deeper → [intercept](intercept.md) · [handoff](handoff.md) · [trusted-endpoints](trusted-endpoints.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,5 +28,10 @@ SourceryKit intercepts an agent’s outbound HTTP calls, enforces endpoint polic
 
 ---
 
-**Next:** set up and run → [onboarding](onboarding.md) · [example](example.md) ·
-go deeper → [intercept](intercept.md) · [handoff](handoff.md) · [trusted-endpoints](trusted-endpoints.md)
+**Next steps:**
+
+- [Onboarding](onboarding.md) — one-time account, credentials, and database setup
+- [End-to-End Walkthrough](example.md) — run the whole flow in code
+- [Intercept](intercept.md) — how outbound HTTP calls are captured and recorded
+- [Handoff](handoff.md) — building claims and reading the verdict
+- [Trusted Endpoints](trusted-endpoints.md) — the outbound allow-list

--- a/docs/example.md
+++ b/docs/example.md
@@ -32,7 +32,7 @@ from sourcerykit import (
 )
 
 # Fire up the local runtime environment and database connections
-await bootstrap_system()
+await bootstrap_system()  # call before any other SDK call
 
 # Add the target API pattern to your real-time allow-list policy registry
 await insert_trusted_endpoint(url="https://api.open-meteo.com/v1/forecast")
@@ -165,3 +165,8 @@ The agent will populate `claimed_values` with a fabricated temperature. When the
   "errors": []
 }
 ```
+
+---
+
+**Next:** what each piece does → [architecture](architecture.md) ·
+claims + verdicts in depth → [handoff](handoff.md) · first-time setup → [onboarding](onboarding.md)

--- a/docs/example.md
+++ b/docs/example.md
@@ -168,5 +168,8 @@ The agent will populate `claimed_values` with a fabricated temperature. When the
 
 ---
 
-**Next:** what each piece does → [architecture](architecture.md) ·
-claims + verdicts in depth → [handoff](handoff.md) · first-time setup → [onboarding](onboarding.md)
+**Next steps:**
+
+- [Architecture](architecture.md) — what each piece does and how they fit together
+- [Handoff](handoff.md) — claims and verdicts in depth
+- [Onboarding](onboarding.md) — first-time account, credentials, and database setup

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -57,6 +57,11 @@ print(f"Evaluation Verdict: {result.get('outcome')}")
 # Returns: {"outcome": "PASS" | "CAUGHT" | "ERROR", "per_claim": [...], "errors": [...]}
 ```
 
+> [!IMPORTANT]
+> Always inspect `per_claim`, not just `outcome`. Each entry is one verified claim; if zero
+> claims could be resolved (e.g. a claim never matched an intercept record), the outcome is
+> `ERROR` — nothing was actually verified.
+
 ## Anatomy of the payload_data
 The `build_handoff_payload` function accepts a structured `payload_data` dictionary. Other runtime fields—such as network intercepts, organization IDs, and API keys—are resolved automatically by the SDK during compilation.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -57,10 +57,12 @@ print(f"Evaluation Verdict: {result.get('outcome')}")
 # Returns: {"outcome": "PASS" | "CAUGHT" | "ERROR", "per_claim": [...], "errors": [...]}
 ```
 
-> [!IMPORTANT]
-> Always inspect `per_claim`, not just `outcome`. Each entry is one verified claim; if zero
-> claims could be resolved (e.g. a claim never matched an intercept record), the outcome is
-> `ERROR` — nothing was actually verified.
+`outcome` is the overall verdict:
+
+- `PASS` — every claim was verified against the recorded data and matched.
+- `CAUGHT` — at least one claim did not match the recorded data, or used an untrusted endpoint.
+- `ERROR` — nothing could be verified (for example, no claim matched an intercept record).
+  Verifying zero claims always resolves to `ERROR`, never `PASS`.
 
 ## Anatomy of the payload_data
 The `build_handoff_payload` function accepts a structured `payload_data` dictionary. Other runtime fields—such as network intercepts, organization IDs, and API keys—are resolved automatically by the SDK during compilation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ cli
 :maxdepth: 1
 :caption: Getting Started
 
+onboarding
 example
 ```
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -3,33 +3,39 @@
 Everything SourceryKit needs before you write code: an account, credentials, and a database.
 This is the **first** step — nothing else works until the credentials below exist.
 
-## ⚠️ A human must complete this once
+## ⚠️ One human step
 
-Onboarding creates a Provably account, and the backend sends an **email verification link
-that only a human can click**. An automated agent cannot finish this step alone. If you are
-an agent, check with `sourcerykit doctor`; if credentials are missing, STOP and ask a human
-to run the setup below, then continue once `doctor` passes.
+Registration triggers an **email verification link that only a human can click** — that is
+the single step an automated agent cannot do. Everything else (register, login, database
+link, project setup) runs non-interactively. If you are an agent: check with
+`sourcerykit doctor`, drive the setup below yourself, and ask a human only for the
+verification click.
 
-## Run the wizard
+## Setup
 
 ```bash
 pip install sourcerykit
-sourcerykit init          # interactive onboarding wizard
 ```
 
-The wizard will:
-
-1. **Sign up** (or **log in** to an existing account) with an email address.
-2. Prompt the human to **verify that email** — click the link the backend sends. Login does
-   not succeed until this is done.
-3. Ask for a **hosted, publicly reachable** Postgres URL (see below).
-4. Issue your credentials and write them to `.env`.
-
-Already have a verified account? `init` also runs non-interactively:
+Non-interactive (agents and scripts):
 
 ```bash
-sourcerykit init --email you@example.com --password ... --postgres-url postgresql://... --project-name my-app
+# 1. register (skip if the account exists) — triggers the verification email
+sourcerykit init --register --email you@example.com --password ...
+
+# 2. a HUMAN clicks the verification link in the email
+
+# 3. log in + link the database + name the project
+sourcerykit init --email you@example.com --password ... \
+  --postgres-url postgresql://user:pass@host:5432/db --project-name my-app
+
+# 4. verify everything works
+sourcerykit doctor
 ```
+
+Interactive: run `sourcerykit init` with no flags and follow the wizard — same steps,
+prompted (sign up or log in → verify email → link a **hosted, publicly reachable**
+Postgres → name the project → credentials stored).
 
 Full command reference (`init`, `doctor`, `endpoints`, `config`, `trace`): [cli.md](cli.md).
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -7,8 +7,8 @@ This is the **first** step — nothing else works until the credentials below ex
 
 Registration triggers an **email verification link that only a human can click** — that is
 the single step an automated agent cannot do. Everything else (register, login, database
-link, project setup) runs non-interactively. If you are an agent: check with
-`sourcerykit doctor`, drive the setup below yourself, and ask a human only for the
+link, project setup) runs non-interactively. If you are an agent: run the setup below
+yourself (it ends with a `sourcerykit doctor` check) and ask a human only for the
 verification click.
 
 ## Setup

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,64 @@
+# Onboarding & Setup
+
+Everything SourceryKit needs before you write code: an account, credentials, and a database.
+This is the **first** step — nothing else works until `.env` holds the three variables below.
+
+## ⚠️ A human must complete this once
+
+Onboarding creates a Provably account, and the backend sends an **email verification link
+that only a human can click**. An automated agent cannot finish this step alone. If you are
+an agent and these credentials are not yet present, STOP and ask a human to run the setup
+below, then continue once `.env` exists.
+
+## Run the wizard
+
+```bash
+pip install sourcerykit
+sourcerykit init          # interactive onboarding wizard
+```
+
+The wizard will:
+
+1. **Sign up** (or **log in** to an existing account) with an email address.
+2. Prompt the human to **verify that email** — click the link the backend sends. Login does
+   not succeed until this is done.
+3. Ask for a **hosted, publicly reachable** Postgres URL (see below).
+4. Issue your credentials and write them to `.env`.
+
+Already have a verified account? `init` also runs non-interactively:
+
+```bash
+sourcerykit init --email you@example.com --password ... --postgres-url postgresql://... --project-name my-app
+```
+
+Full command reference (`init`, `doctor`, `endpoints`, `config`, `trace`): [cli.md](cli.md).
+
+## The credentials
+
+| Variable | What it is |
+|---|---|
+| `SOURCERYKIT_API_KEY` | Provably API key. Issued at login — never hand-write it. |
+| `SOURCERYKIT_ORG_ID` | Organisation UUID. Paired with the key; issued together. |
+| `SOURCERYKIT_POSTGRES_URL` | DSN for the database SourceryKit records intercepts in. |
+
+> [!NOTE]
+> The Postgres database must be **hosted and publicly reachable** — the Provably backend
+> connects to it directly to generate proofs. `localhost` / `127.0.0.1` will not work.
+
+Do not fabricate the API key or org id, and do not pair a key with an org it was not issued
+with — the two are minted together at login.
+
+## Manual configuration (alternative)
+
+If you already have credentials, you can export them instead of running the wizard:
+
+```bash
+export SOURCERYKIT_API_KEY="..."
+export SOURCERYKIT_ORG_ID="..."
+export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
+```
+
+---
+
+**Next:** run the full flow → [End-to-End Walkthrough](example.md) ·
+look up a function → [Public API](src/api.md)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -8,8 +8,7 @@ This is the **first** step — nothing else works until the credentials below ex
 Registration triggers an **email verification link that only a human can click** — that is
 the single step an automated agent cannot do. Everything else (register, login, database
 link, project setup) runs non-interactively. If you are an agent: run the setup below
-yourself (it ends with a `sourcerykit doctor` check) and ask a human only for the
-verification click.
+yourself and ask a human only for the verification click.
 
 ## Setup
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,14 +1,14 @@
 # Onboarding & Setup
 
 Everything SourceryKit needs before you write code: an account, credentials, and a database.
-This is the **first** step — nothing else works until `.env` holds the three variables below.
+This is the **first** step — nothing else works until the credentials below exist.
 
 ## ⚠️ A human must complete this once
 
 Onboarding creates a Provably account, and the backend sends an **email verification link
 that only a human can click**. An automated agent cannot finish this step alone. If you are
-an agent and these credentials are not yet present, STOP and ask a human to run the setup
-below, then continue once `.env` exists.
+an agent, check with `sourcerykit doctor`; if credentials are missing, STOP and ask a human
+to run the setup below, then continue once `doctor` passes.
 
 ## Run the wizard
 
@@ -35,25 +35,23 @@ Full command reference (`init`, `doctor`, `endpoints`, `config`, `trace`): [cli.
 
 ## The credentials
 
-| Variable | What it is |
-|---|---|
-| `SOURCERYKIT_API_KEY` | Provably API key. Issued at login — never hand-write it. |
-| `SOURCERYKIT_ORG_ID` | Organisation UUID. Paired with the key; issued together. |
-| `SOURCERYKIT_POSTGRES_URL` | DSN for the database SourceryKit records intercepts in. |
+`init` stores credentials at two levels (see [cli.md](cli.md) for the full table):
+
+- **Global config** (OS application directory, shared across projects): the Provably
+  **API key** and **organisation id** — issued together at login; never hand-write them.
+- **Project `.env`**: `SOURCERYKIT_POSTGRES_URL` (the database SourceryKit records
+  intercepts in), `SOURCERYKIT_PROJECT_NAME`, and the bootstrap resource ids.
 
 > [!NOTE]
 > The Postgres database must be **hosted and publicly reachable** — the Provably backend
 > connects to it directly to generate proofs. `localhost` / `127.0.0.1` will not work.
 
-Do not fabricate the API key or org id, and do not pair a key with an org it was not issued
-with — the two are minted together at login.
-
 ## Manual configuration (alternative)
 
-If you already have credentials, you can export them instead of running the wizard:
+Already have credentials? Environment variables override the stored config:
 
 ```bash
-export SOURCERYKIT_API_KEY="..."
+export PROVABLY_API_KEY="..."
 export SOURCERYKIT_ORG_ID="..."
 export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# SourceryKit
+
+> Python SDK for Provably: verifiable guardrails for AI agents — records outbound HTTP
+> calls, enforces endpoint policies, and checks an agent's claims against what those calls
+> actually returned. Claims come from the agent's structured output; mismatches are CAUGHT.
+
+Agent entry point: [AGENTS.md](AGENTS.md) — the machine landing page. Start there.
+
+## Docs
+
+- [Onboarding & setup (one-time, needs a human)](docs/onboarding.md)
+- [End-to-end walkthrough](docs/example.md)
+- [Public API reference](docs/src/api.md)
+- [CLI reference](docs/cli.md)
+- [Architecture](docs/architecture.md)
+- [Intercepting HTTP calls](docs/intercept.md)
+- [Handoff payload & verdicts](docs/handoff.md)
+- [Trusted endpoints](docs/trusted-endpoints.md)
+
+## Examples
+
+- [OpenAI Agents SDK integration](cookbooks/openai_agents/agent_run.py)
+- [Claude Agent SDK integration](cookbooks/claude_agent/agent_run.py)
+- [LangChain integration](cookbooks/langchain_agent/agent_run.py)
+
+## Install
+
+`pip install sourcerykit` (Python 3.12+, PyPI: sourcerykit)


### PR DESCRIPTION
## Changes
- AGENTS.md — landing page for AI agents: human-gate warning, install, pick-your-path table, flow at a glance, outcome semantics. Will be the source for the machine version of the provably.ai landing page.
- llms.txt — web-convention entry point mirroring AGENTS.md pointers.
- docs/onboarding.md — one-time setup guide (wizard, email verify, hosted Postgres, non-interactive init); added to the Getting Started toctree.
- Breadcrumb footers on architecture/example/handoff + a per_claim inspection note.

## Why
Agents landing on this repo (or the site) need a deterministic entry point that routes them to the right doc in one hop, states the one human-gated step up front, and names the cookbooks as ground truth for a correct integration. This PR is also the working branch for the discoverability bench — future data-backed doc improvements land here as follow-up commits.