### PR TITLE
docs: improve intercept references and update LLM configurations

### DIFF
--- a/cookbooks/crewai_multi_agent/README.md
+++ b/cookbooks/crewai_multi_agent/README.md
@@ -45,9 +45,10 @@ sourcerykit init
 
 | Variable | Required | Description |
 |---|---|---|
-| `MODEL_URL` | **yes** | Base URL routing endpoint for the LLM processing interface (e.g., `https://openrouter.ai/api/v1`). |
-| `MODEL_API_KEY` | **yes** | API authentication token for the targeting model processing engine. |
 | `MODEL_NAME` | **yes** | Targeted model engine name (e.g., `openai/gpt-4o-mini`). |
+
+> [!Note]
+> Ensure your underlying model provider's environment variables—such as `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`—are also set as required by your CrewAI provider setup.
 
 ---
 
@@ -64,9 +65,8 @@ sourcerykit init
    ```
 2. Export your LLM-provider keys:
    ```bash
-   export MODEL_URL="https://openrouter.ai/api/v1"
-   export MODEL_API_KEY="sk-or-..."
    export MODEL_NAME="openai/gpt-4o-mini"
+   export OPENAI_API_KEY="sk-..."
    ```
 3. Run:
    ```bash

--- a/docs/example.md
+++ b/docs/example.md
@@ -46,7 +46,7 @@ When the agent executes an HTTP request, we wrap it inside `async_intercept_cont
 @function_tool
 async def get_current_temperature_london() -> dict:
     """Fetch the current temperature in London from Open-Meteo."""
-    async with async_intercept_context(agent_id="demo-agent", action_name="get_weather"):
+    async with async_intercept_context(agent_id="demo-agent", action_name="get_weather") as ref:
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "https://api.open-meteo.com/v1/forecast",
@@ -54,8 +54,17 @@ async def get_current_temperature_london() -> dict:
                 timeout=30,
             )
             response.raise_for_status()
-            return response.json()
+            data = response.json()
+    return {**data, "sourcerykit_ref": ref}
 ```
+
+> [!TIP]
+> When the same tool is called multiple times (e.g., weather for London and Paris), each
+> `async_intercept_context` invocation produces a unique `ref`. Return it alongside the
+> data so the agent can map each `claimed_value` to the correct intercept via
+> `sourcerykit_ref`. See the
+> [claude_agent_multi_tool](../cookbooks/claude_agent_multi_tool) cookbook for a runnable
+> example.
 
 ### Step 3: LLM Interaction & Claim Extraction
 When the agent runs, it calls the tool, receives the raw JSON response, and passes it to the LLM for reasoning. Configure your agent with `SourceryKitAgentResponse` as the structured output type — the keyword argument depends on your framework (e.g., `output_type` for the OpenAI Agents SDK, `response_format` for LangChain). The LLM returns a typed `SourceryKitAgentResponse` with a `claimed_values` list — a flat collection of `ClaimedValue` objects, each with a JSONPath-style `path` and the extracted value as a string.

--- a/docs/intercept.md
+++ b/docs/intercept.md
@@ -18,14 +18,17 @@ import httpx
 # Initialize runtime, database schema, and interceptors
 await sourcerykit.bootstrap_system()
 
-# Intercept and tag outbound network activity
-async with sourcerykit.async_intercept_context(agent_id="demo", action_name="get_data"):
+# Intercept and tag outbound network activity — returns a unique ref
+async with sourcerykit.async_intercept_context(agent_id="demo", action_name="get_data") as ref:
     async with httpx.AsyncClient() as client:
         response = await client.get(
             "https://api.example.com/data",
             params={"query": "example_parameter"}
         )
         data = response.json()
+
+# Return ref alongside data so the agent can map claims to this intercept
+return {**data, "sourcerykit_ref": ref}
 ```
 
 ## Key Features


### PR DESCRIPTION
This PR updates the documentation to detail how unique references are returned for outbound intercept contexts and clarifies the environment configuration requirements for LLM provider keys.