### PR TITLE
bump: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 1.0.1
+## Unreleased
 
 ## 1.0.1
+
+### Bug fixes
+- Fix preprocessing edge case — handle new tables by safely catching the 404 Not Found response when no initial preprocessing status record exists yet.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 1.0.1
+
+## 1.0.1
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br />
 
   [![PyPI Version](https://img.shields.io/pypi/v/sourcerykit.svg?color=blue)](https://pypi.org/project/sourcerykit/)
-  [![status: v1.0.0](https://img.shields.io/badge/status-v1.0.0-blue)](https://github.com/ProvablyAI/sourcerykit/blob/main/CHANGELOG.md)
+  [![status: v1.0.1](https://img.shields.io/badge/status-v1.0.1-blue)](https://github.com/ProvablyAI/sourcerykit/blob/main/CHANGELOG.md)
   [![python: 3.12+](https://img.shields.io/badge/python-3.12+-slate)](https://github.com/ProvablyAI/sourcerykit/blob/main/pyproject.toml)
   [![license: BSL 1.1](https://img.shields.io/badge/license-BSL%201.1-crimson)](https://github.com/ProvablyAI/sourcerykit/blob/main/LICENSE.md)
   [![CI Build](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml/badge.svg)](https://github.com/ProvablyAI/sourcerykit/actions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sourcerykit"
-version = "1.0.0"
+version = "1.0.1"
 description = "Counterspell for hallucinating agents. Python SDK that breaks the illusion on every tool call, API response, and MCP handoff before bad outputs propagate."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"
@@ -138,7 +138,7 @@ exclude_also = ["if TYPE_CHECKING:", "raise NotImplementedError", "\\.\\.\\."]
 sourcerykit = "sourcerykit.cli.main:app"
 
 [tool.bumpversion]
-current_version = "1.0.0"
+current_version = "1.0.1"
 commit = false
 tag = false
 tag_name = "v{new_version}"

--- a/uv.lock
+++ b/uv.lock
@@ -2188,7 +2188,7 @@ wheels = [
 
 [[package]]
 name = "sourcerykit"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
bump: 1.0.1

### Bug fixes
- Fix preprocessing edge case — handle new tables by safely catching the 404 Not Found response when no initial preprocessing status record exists yet.