### PR TITLE
Improve PyPI/GitHub discoverability: keywords, classifiers, badges, py.typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/logo.svg" alt="SourceryKit" width="180" />
+  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/logo.svg" alt="SourceryKit" width="220" />
 
   <br />
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,7 @@ SourceryKit is the Python SDK for [Provably](https://provably.ai). It provides v
 - **Deterministic verdicts** — every run resolves to `PASS`, `CAUGHT`, or `ERROR` against cryptographically anchored records.
 - **Framework-agnostic** — drops into OpenAI Agents SDK, LangChain, Claude Agent SDK, CrewAI, and LangGraph.
 
-
-## How Does It Work?
-
-SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
-
-### The Pieces
+Under the hood, these are the pieces doing the work:
 
 - **HTTP Interceptor**: Patches your HTTP libraries to watch and log outbound calls, blocking untrusted requests on the spot.
 - **Trusted Endpoints**: A database allow-list of approved destinations for your agent.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ SourceryKit is the Python SDK for [Provably](https://provably.ai). It provides v
 > ⚠️ **IMPORTANT:** Upgrading the SDK from v0.2 to v1.0? See the [v1.0 migration guide](https://github.com/ProvablyAI/sourcerykit/blob/main/docs/migrations/v1_0/v1_0.md).
 
 
+## Features
+
+- **Verifiable guardrails** — checks your agent's claims against recorded ground truth, so a hallucinated value is caught before it ships.
+- **Automatic HTTP interception** — records every outbound call (`httpx`, `aiohttp`, `requests`) with no changes to your agent code.
+- **Endpoint allow-listing** — blocks requests to untrusted destinations at the source.
+- **Deterministic verdicts** — every run resolves to `PASS`, `CAUGHT`, or `ERROR` against cryptographically anchored records.
+- **Framework-agnostic** — drops into OpenAI Agents SDK, LangChain, Claude Agent SDK, CrewAI, and LangGraph.
+
+
+## How Does It Work?
+
+SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
+
+### The Pieces
+
+- **HTTP Interceptor**: Patches your HTTP libraries to watch and log outbound calls, blocking untrusted requests on the spot.
+- **Trusted Endpoints**: A database allow-list of approved destinations for your agent.
+- **Intercepts Table**: An append-only DB table that logs every request and response for auditing.
+- **SourceryKitAgentResponse**: A Pydantic model used as the structured response_format for your agent. Enforces a typed response contract with a `claimed_values` list of extracted values.
+- **Handoff Payload**: A clean data bundle containing the claims your agent is making about its external actions.
+- **Evaluator**: Compares the handoff payload against records in the Provably backend to give you a clear verdict.
+- **Provably Backend**: The source of truth that turns your local intercepts into anchored verification proofs.
+
+
 ## Quickstart
 
 Requires **Python 3.12+**.
@@ -93,21 +117,6 @@ async def run_verifiable_agent():
     result = await sourcerykit.evaluate_handoff(payload=payload)
     print(f"Evaluation Outcome: {result.get('outcome')}") # PASS, CAUGHT, or ERROR
 ```
-
-
-## How Does It Work?
-
-SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
-
-### The Pieces
-
-- **HTTP Interceptor**: Patches your HTTP libraries to watch and log outbound calls, blocking untrusted requests on the spot.
-- **Trusted Endpoints**: A database allow-list of approved destinations for your agent.
-- **Intercepts Table**: An append-only DB table that logs every request and response for auditing.
-- **SourceryKitAgentResponse**: A Pydantic model used as the structured response_format for your agent. Enforces a typed response contract with a `claimed_values` list of extracted values.
-- **Handoff Payload**: A clean data bundle containing the claims your agent is making about its external actions.
-- **Evaluator**: Compares the handoff payload against records in the Provably backend to give you a clear verdict.
-- **Provably Backend**: The source of truth that turns your local intercepts into anchored verification proofs.
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -16,6 +16,32 @@ SourceryKit is the Python SDK for [Provably](https://provably.ai). It provides v
 > ⚠️ **IMPORTANT:** Upgrading the SDK from v0.2 to v1.0? See the [v1.0 migration guide](https://github.com/ProvablyAI/sourcerykit/blob/main/docs/migrations/v1_0/v1_0.md).
 
 
+## Quickstart
+
+Requires **Python 3.12+**.
+
+```bash
+pip install sourcerykit
+sourcerykit init          # one-time setup: account, database, credentials
+```
+
+Give your agent `SourceryKitAgentResponse` as its output type, then verify its claims against the recorded calls before you trust them:
+
+```python
+import sourcerykit
+from sourcerykit import SourceryKitAgentResponse  # your agent's output_type
+
+await sourcerykit.bootstrap_system()
+await sourcerykit.insert_trusted_endpoint(url="https://api.example.com/data")
+
+# ... run your agent inside an intercept context, then build the payload ...
+result = await sourcerykit.evaluate_handoff(payload=payload)
+print(result["outcome"])  # PASS | CAUGHT | ERROR
+```
+
+See the [full runnable example](#quick-example) below.
+
+
 ## How Does It Work?
 
 SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
@@ -33,22 +59,6 @@ SourceryKit handles policy enforcement and logging right inside your agent's nor
 - **Handoff Payload**: A clean data bundle containing the claims your agent is making about its external actions.
 - **Evaluator**: Compares the handoff payload against records in the Provably backend to give you a clear verdict.
 - **Provably Backend**: The source of truth that turns your local intercepts into anchored verification proofs.
-
-
-## Installation
-
-SourceryKit requires **Python 3.12+**. You can grab it directly from source:
-
-```bash
-git clone git@github.com:ProvablyAI/sourcerykit.git
-pip install -e ./sourcerykit
-```
-
-Or install it directly via pip:
-
-```bash
-pip install sourcerykit
-```
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 
   <br />
 
-  [![CI](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml/badge.svg)](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml)
   [![PyPI version](https://img.shields.io/pypi/v/sourcerykit)](https://pypi.org/project/sourcerykit/)
   [![Python versions](https://img.shields.io/pypi/pyversions/sourcerykit)](https://pypi.org/project/sourcerykit/)
-  [![License](https://img.shields.io/pypi/l/sourcerykit)](https://github.com/ProvablyAI/sourcerykit/blob/main/LICENSE.md)
-  [![Types: Mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
+  [![License: BSL 1.1](https://img.shields.io/badge/license-BSL%201.1-blue)](https://github.com/ProvablyAI/sourcerykit/blob/main/LICENSE.md)
+  [![CI](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml/badge.svg)](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml)
 </div>
 
 
@@ -25,77 +24,14 @@ pip install sourcerykit
 sourcerykit init          # one-time setup: account, database, credentials
 ```
 
-Give your agent `SourceryKitAgentResponse` as its output type, then verify its claims against the recorded calls before you trust them:
-
-```python
-import sourcerykit
-from sourcerykit import SourceryKitAgentResponse  # your agent's output_type
-
-await sourcerykit.bootstrap_system()
-await sourcerykit.insert_trusted_endpoint(url="https://api.example.com/data")
-
-# ... run your agent inside an intercept context, then build the payload ...
-result = await sourcerykit.evaluate_handoff(payload=payload)
-print(result["outcome"])  # PASS | CAUGHT | ERROR
-```
-
-See the [full runnable example](#quick-example) below.
-
-
-## How Does It Work?
-
-SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/architecture.svg" alt="architecture" width="550" />
-</div>
-
-### The Pieces
-
-- **HTTP Interceptor**: Patches your HTTP libraries to watch and log outbound calls, blocking untrusted requests on the spot.
-- **Trusted Endpoints**: A database allow-list of approved destinations for your agent.
-- **Intercepts Table**: An append-only DB table that logs every request and response for auditing.
-- **SourceryKitAgentResponse**: A Pydantic model used as the structured response_format for your agent. Enforces a typed response contract with a `claimed_values` list of extracted values.
-- **Handoff Payload**: A clean data bundle containing the claims your agent is making about its external actions.
-- **Evaluator**: Compares the handoff payload against records in the Provably backend to give you a clear verdict.
-- **Provably Backend**: The source of truth that turns your local intercepts into anchored verification proofs.
-
-
-## Configuration
-To get things running, SourceryKit must be configured with your project variables. The interactive CLI handles account provisioning, organization workspace initialization, database validation, and persists credentials globally (OS application folder) and locally (project `.env`).
+Or install from source:
 
 ```bash
-sourcerykit init
+git clone git@github.com:ProvablyAI/sourcerykit.git
+pip install -e ./sourcerykit
 ```
 
-The wizard will guide you through:
-- **Account Setup & Authorization**: Create a new account or log into an existing one, and select your organization workspace.
-- **API Key Generation**: Automatically fetch your SDK API-KEY from your account profile.
-- **Database Handshake**: Enter your database details, test the connection, and ensure it's accessible.
-- **Save Config**: Automatically write your credentials and tokens straight to a local .env file.
-
-> ⚠️ **IMPORTANT:** The wizard only configures **SOURCERYKIT_*** variables. It does **not** handle third-party LLM provider infrastructure keys, which must still be exported separately.
-
-### Manual configuration (fallback)
-
-Already have credentials, or need to bypass the wizard (CI, containers, debugging)? Environment
-variables override the stored config:
-
-```bash
-export PROVABLY_API_KEY="..."
-export SOURCERYKIT_ORG_ID="..."
-export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
-```
-
-For a full list of CLI commands, check out the [CLI Documentation](https://provably.ai/docs/getting_started/cli) file, or simply run:
-```bash
-sourcerykit --help
-```
-
-For a full list of environment variables, see [.env.example](https://github.com/ProvablyAI/sourcerykit/blob/main/.env.example).
-
-## Quick Example
-Here is how to bootstrap the system, run an intercepted request, build a payload, and check if everything passes validation:
+Bootstrap the system, run an intercepted request, build the payload, and check the verdict:
 
 ```python
 import uuid
@@ -157,6 +93,59 @@ async def run_verifiable_agent():
     result = await sourcerykit.evaluate_handoff(payload=payload)
     print(f"Evaluation Outcome: {result.get('outcome')}") # PASS, CAUGHT, or ERROR
 ```
+
+
+## How Does It Work?
+
+SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/architecture.svg" alt="architecture" width="550" />
+</div>
+
+### The Pieces
+
+- **HTTP Interceptor**: Patches your HTTP libraries to watch and log outbound calls, blocking untrusted requests on the spot.
+- **Trusted Endpoints**: A database allow-list of approved destinations for your agent.
+- **Intercepts Table**: An append-only DB table that logs every request and response for auditing.
+- **SourceryKitAgentResponse**: A Pydantic model used as the structured response_format for your agent. Enforces a typed response contract with a `claimed_values` list of extracted values.
+- **Handoff Payload**: A clean data bundle containing the claims your agent is making about its external actions.
+- **Evaluator**: Compares the handoff payload against records in the Provably backend to give you a clear verdict.
+- **Provably Backend**: The source of truth that turns your local intercepts into anchored verification proofs.
+
+
+## Configuration
+To get things running, SourceryKit must be configured with your project variables. The interactive CLI handles account provisioning, organization workspace initialization, database validation, and persists credentials globally (OS application folder) and locally (project `.env`).
+
+```bash
+sourcerykit init
+```
+
+The wizard will guide you through:
+- **Account Setup & Authorization**: Create a new account or log into an existing one, and select your organization workspace.
+- **API Key Generation**: Automatically fetch your SDK API-KEY from your account profile.
+- **Database Handshake**: Enter your database details, test the connection, and ensure it's accessible.
+- **Save Config**: Automatically write your credentials and tokens straight to a local .env file.
+
+> ⚠️ **IMPORTANT:** The wizard only configures **SOURCERYKIT_*** variables. It does **not** handle third-party LLM provider infrastructure keys, which must still be exported separately.
+
+### Manual configuration (fallback)
+
+Already have credentials, or need to bypass the wizard (CI, containers, debugging)? Environment
+variables override the stored config:
+
+```bash
+export PROVABLY_API_KEY="..."
+export SOURCERYKIT_ORG_ID="..."
+export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
+```
+
+For a full list of CLI commands, check out the [CLI Documentation](https://provably.ai/docs/getting_started/cli) file, or simply run:
+```bash
+sourcerykit --help
+```
+
+For a full list of environment variables, see [.env.example](https://github.com/ProvablyAI/sourcerykit/blob/main/.env.example).
 
 
 ## More Docs

--- a/README.md
+++ b/README.md
@@ -24,20 +24,6 @@ pip install sourcerykit
 sourcerykit init          # one-time setup: account, database, credentials
 ```
 
-Give your agent `SourceryKitAgentResponse` as its output type, then verify its claims before you trust them:
-
-```python
-import sourcerykit
-from sourcerykit import SourceryKitAgentResponse  # your agent's output_type
-
-await sourcerykit.bootstrap_system()
-await sourcerykit.insert_trusted_endpoint(url="https://api.example.com/data")
-
-# ... run your agent inside an intercept context, then build the payload ...
-result = await sourcerykit.evaluate_handoff(payload=payload)
-print(result["outcome"])  # PASS | CAUGHT | ERROR
-```
-
 Prefer installing from source?
 
 ```bash
@@ -45,10 +31,7 @@ git clone git@github.com:ProvablyAI/sourcerykit.git
 pip install -e ./sourcerykit
 ```
 
-
-## Example
-
-Bootstrap the system, run an intercepted request, build the payload, and check the verdict:
+Give your agent `SourceryKitAgentResponse` as its output type, run it inside an intercept context, then check the verdict before you trust its claims:
 
 ```python
 import uuid
@@ -115,10 +98,6 @@ async def run_verifiable_agent():
 ## How Does It Work?
 
 SourceryKit handles policy enforcement and logging right inside your agent's normal workflow:
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/architecture.svg" alt="architecture" width="550" />
-</div>
 
 ### The Pieces
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/logo.svg" alt="SourceryKit" width="280" />
+  <img src="https://raw.githubusercontent.com/ProvablyAI/sourcerykit/refs/heads/main/docs/images/logo.svg" alt="SourceryKit" width="180" />
 
   <br />
 
@@ -24,12 +24,29 @@ pip install sourcerykit
 sourcerykit init          # one-time setup: account, database, credentials
 ```
 
-Or install from source:
+Give your agent `SourceryKitAgentResponse` as its output type, then verify its claims before you trust them:
+
+```python
+import sourcerykit
+from sourcerykit import SourceryKitAgentResponse  # your agent's output_type
+
+await sourcerykit.bootstrap_system()
+await sourcerykit.insert_trusted_endpoint(url="https://api.example.com/data")
+
+# ... run your agent inside an intercept context, then build the payload ...
+result = await sourcerykit.evaluate_handoff(payload=payload)
+print(result["outcome"])  # PASS | CAUGHT | ERROR
+```
+
+Prefer installing from source?
 
 ```bash
 git clone git@github.com:ProvablyAI/sourcerykit.git
 pip install -e ./sourcerykit
 ```
+
+
+## Example
 
 Bootstrap the system, run an intercepted request, build the payload, and check the verdict:
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@
 
   <br />
 
-  [![PyPI Version](https://img.shields.io/pypi/v/sourcerykit.svg?color=blue)](https://pypi.org/project/sourcerykit/)
-  [![status: v1.0.1](https://img.shields.io/badge/status-v1.0.1-blue)](https://github.com/ProvablyAI/sourcerykit/blob/main/CHANGELOG.md)
-  [![python: 3.12+](https://img.shields.io/badge/python-3.12+-slate)](https://github.com/ProvablyAI/sourcerykit/blob/main/pyproject.toml)
-  [![license: BSL 1.1](https://img.shields.io/badge/license-BSL%201.1-crimson)](https://github.com/ProvablyAI/sourcerykit/blob/main/LICENSE.md)
-  [![CI Build](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml/badge.svg)](https://github.com/ProvablyAI/sourcerykit/actions)
-  [![Coverage](https://img.shields.io/badge/coverage-60%25-success)](https://github.com/ProvablyAI/sourcerykit)
+  [![CI](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml/badge.svg)](https://github.com/ProvablyAI/sourcerykit/actions/workflows/ci.yml)
+  [![PyPI version](https://img.shields.io/pypi/v/sourcerykit)](https://pypi.org/project/sourcerykit/)
+  [![Python versions](https://img.shields.io/pypi/pyversions/sourcerykit)](https://pypi.org/project/sourcerykit/)
+  [![License](https://img.shields.io/pypi/l/sourcerykit)](https://github.com/ProvablyAI/sourcerykit/blob/main/LICENSE.md)
+  [![Types: Mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
 </div>
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
     "Topic :: System :: Monitoring",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,30 @@ keywords = [
     "provably",
     "verifiable",
     "agent",
+    "ai-agents",
+    "llm",
+    "guardrails",
+    "llm-security",
+    "observability",
+    "hallucination",
     "handoff",
     "interceptor",
 ]
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Topic :: Security",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: System :: Monitoring",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: OS Independent",
+    "Typing :: Typed",
 ]
 dependencies = [
     "alembic>=1.13",
@@ -158,11 +174,6 @@ depends_on = "pre"
 filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
-
-[[tool.bumpversion.files]]
-filename = "README.md"
-search = "v{current_version}"
-replace = "v{new_version}"
 
 [[tool.bumpversion.files]]
 filename = "CHANGELOG.md"


### PR DESCRIPTION
## Changes

- **Keywords**: add `ai-agents, llm, guardrails, llm-security, observability, hallucination`.
- **Classifiers**: add Development Status, Intended Audience, Topic (Security / HTTP / Monitoring / Libraries), `Python :: 3 :: Only`, `Implementation :: CPython`, `Typing :: Typed`. All strings verified against pypi.org/classifiers and accepted by a clean build.
- **py.typed**: new PEP 561 marker so consumers' type-checkers get the shipped types. Makes the `Typing :: Typed` and mypy badge honest.
- **README badges**: 5 live badges — CI, PyPI version, Python versions, License, Types-Mypy. Dropped the static `status`/`coverage` badges and stars/downloads.
- **bumpversion**: drop the README hook (its `v1.0.0` target was the removed status badge).

## Why

Richer valid classifiers and search keywords improve PyPI findability; live badges stay accurate with no upkeep. Badge set follows what mature Python tools ship (httpx, ruff, pydantic): version/license/python/CI are the credible core, and low stars/downloads on a new package read as vanity, so they wait. SPDX `license = "BUSL-1.1"` (PEP 639) is left for a separate PR since it changes packaging metadata.