### PR TITLE
Feat/oauth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # `.env` is git- and docker-ignored; `.env.example` is the canonical list.
 #
 # Two-tier config:
-#   Global (OS config folder for applications): api_key, org_id (user-level)
+#   Global (OS config folder for applications): access_token, refresh_token, org_id (user-level)
 #   Local  (.env): everything else (project-level)
 #
 # All vars below can be set via env vars or in .env.
@@ -14,9 +14,13 @@
 
 # ===== Global config (set via `sourcerykit init`, stored in OS app dir) =======
 
-# Provably integration API key
-# Read by: get_settings() -> Settings.api_key
-PROVABLY_API_KEY=zk-XXX
+# OAuth access token (issued by `sourcerykit init`; auto-refreshed via the refresh token)
+# Read by: get_settings() -> Settings.access_token
+PROVABLY_ACCESS_TOKEN=
+
+# OAuth refresh token (rotated on each refresh)
+# Read by: get_settings() -> Settings.refresh_token
+PROVABLY_REFRESH_TOKEN=
 
 # Provably organisation UUID
 # Read by: get_settings() -> Settings.org_id
@@ -45,6 +49,11 @@ SOURCERYKIT_ORG_ID=00000000-0000-0000-0000-000000000000
 # SOURCERYKIT_INTEGRATION_KEY=
 
 # ===== Optional (override defaults) ===========================================
+
+# Token store path for the embedded-app flow. When set, rotated OAuth tokens are
+# persisted to this .env file instead of the global config JSON, keeping an app's
+# session isolated from the standalone SDK's global config.
+# SOURCERYKIT_TOKEN_STORE=/path/to/app/sourcerykit.env
 
 # SOURCERYKIT_PROVABLY_APP_URL=https://app.provably.ai
 # SOURCERYKIT_PROVABLY_API_URL=https://api.provably.ai

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,10 @@ agent's claims against what those calls actually returned, so a hallucinated val
 **caught** instead of shipped.
 
 > [!IMPORTANT]
-> **Setup is scriptable — prefer the non-interactive `sourcerykit init` CLI over
-> hand-writing config.** Exactly one step needs a human: clicking the email-verification
-> link. Full steps: [docs/onboarding.md](docs/onboarding.md).
+> **Setup is scriptable — prefer the `sourcerykit init` CLI over hand-writing config.**
+> Exactly one step needs a human: completing the browser OAuth login (new accounts are
+> created on the Provably web app during that login). Full steps:
+> [docs/onboarding.md](docs/onboarding.md).
 
 ## Where to go next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking changes
+- **OAuth browser-only login** — `sourcerykit init` no longer accepts `--register`, `--email`, or `--password`; email/password login and account registration were removed. Login is browser-based OAuth (PKCE) only. `--postgres-url`, `--project-name`, and `--sandbox` still work: passing any flag opens the browser login once, then continues non-interactively. New accounts are created on the Provably web app during the browser login.
+
 ## 1.1.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## Unreleased
 
 ### Breaking changes
-- **OAuth browser-only login** — `sourcerykit init` no longer accepts `--register`, `--email`, or `--password`; email/password login and account registration were removed. Login is browser-based OAuth (PKCE) only. `--postgres-url`, `--project-name`, and `--sandbox` still work: passing any flag opens the browser login once, then continues non-interactively. New accounts are created on the Provably web app during the browser login.
+- **User API key removed in favor of OAuth tokens** — authentication now uses `PROVABLY_ACCESS_TOKEN` (auto-refreshed via `PROVABLY_REFRESH_TOKEN`); the verify path uses the collection integration key. Existing users must re-run `sourcerykit init`. See the [migration guide](docs/migrations/unreleased/unreleased.md).
+- **OAuth browser-only login** — `--register`, `--email`, and `--password` are removed; login is browser OAuth (PKCE) only. New accounts are created on the Provably web app during login.
+
+### Features
+- **Idempotent integration bootstrap** — re-running `init`/`doctor --fix` reuses the existing integration (exact collection match) instead of minting a duplicate key and shadow user.
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Already have credentials, or need to bypass the wizard (CI, containers, debuggin
 variables override the stored config:
 
 ```bash
-export PROVABLY_API_KEY="..."
+export PROVABLY_ACCESS_TOKEN="..."
+export PROVABLY_REFRESH_TOKEN="..."
 export SOURCERYKIT_ORG_ID="..."
 export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
 ```

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sourcerykit init
 ```
 
 The wizard will guide you through:
-- **Account Setup & Authorization**: Create a new account or log into an existing one, and select your organization workspace.
+- **Account Login (OAuth)**: Log in securely with your browser and select your organization workspace.
 - **API Key Generation**: Automatically fetch your SDK API-KEY from your account profile.
 - **Database Provisioning**: Creates a hosted sandbox database automatically. To use your own PostgreSQL instead, pass `--postgres-url`.
 - **Save Config**: Automatically write your credentials and tokens straight to a local .env file.

--- a/docs/getting_started/cli.md
+++ b/docs/getting_started/cli.md
@@ -39,7 +39,7 @@ SourceryKit stores configuration at two levels:
 
 | Config | Location | Scope | Stores |
 |--------|----------|-------|--------|
-| Global | `typer.get_app_dir("sourcerykit")` (OS application directory) | User-level | `api_key`, `org_id`, `token`, `refresh_token`, `email` |
+| Global | `typer.get_app_dir("sourcerykit")` (OS application directory) | User-level | `token`, `refresh_token`, `email`, `org_id` |
 | Local | `./.env` (project directory) | Project-level | `SOURCERYKIT_POSTGRES_URL`, `SOURCERYKIT_PROJECT_NAME`, bootstrap IDs |
 
 Global config is shared across all projects. Local config is project-specific and should be added to `.gitignore`.
@@ -69,7 +69,6 @@ sourcerykit init [--postgres-url URL] [--project-name NAME] [--sandbox]
 
 **What it does:**
 - Account login (browser OAuth)
-- API key retrieval
 - Sandbox database provisioning (or custom PostgreSQL with `--postgres-url`)
 - Project naming
 - Bootstrap resource creation
@@ -110,7 +109,6 @@ sourcerykit init \
 🎉 SOURCERYKIT SETUP COMPLETE
 
  Global config:
-   PROVABLY_API_KEY    = ***********************************1234
    SOURCERYKIT_ORG_ID  = abc123
 
  Local config (.env):
@@ -139,7 +137,7 @@ sourcerykit doctor [--fix]
 > Run `sourcerykit doctor --fix` to automatically re-create missing bootstrap IDs without going through the full `init` wizard again.
 
 **Checks performed:**
-1. API key validity
+1. Session validity and org membership
 2. Database connectivity (detects sandbox vs personal)
 3. Project name presence
 4. Bootstrap IDs presence
@@ -150,7 +148,7 @@ sourcerykit doctor [--fix]
 ```bash
 🩺 SourceryKit Doctor
 
-  ✅ API key + org: API key valid, org found (1 org(s))
+  ✅ Session + org: Session valid, org found (1 org(s))
   ✅ Database: Sandbox database (postgresql://user:***@host:5432/db)
   ✅ Project name: 'my-project'
   ✅ Bootstrap IDs: All bootstrap IDs present
@@ -164,7 +162,7 @@ All 6 checks passed!
 ```bash
 🩺 SourceryKit Doctor
 
-  ❌ API key + org: API key is invalid or expired — run 'sourcerykit init'
+  ❌ Session + org: Session expired — run 'sourcerykit init'
   ❌ Database: Database connection failed — check SOURCERYKIT_POSTGRES_URL
   ✅ Project name: 'my-project'
   ❌ Bootstrap IDs: Missing: middleware_id, database_id — run 'sourcerykit doctor --fix'
@@ -443,13 +441,13 @@ sourcerykit config list [--show-key]
 | `--show-key` | Show secrets in clear text (default: masked) |
 
 > [!WARNING]
-> `--show-key` prints your API key and database password in clear text. Avoid using it in shared terminals or CI logs.
+> `--show-key` prints your database password in clear text. Avoid using it in shared terminals or CI logs.
 
 **Example output:**
 ```bash
 📋 Global Config
 
-PROVABLY_API_KEY       = ***********************************1234
+SOURCERYKIT_ORG_ID  = abc123
 
 📋 Local Config (.env)
 
@@ -464,18 +462,16 @@ SOURCERYKIT_PROJECT_NAME  = 'my-project'
 Update configuration variables.
 
 ```bash
-sourcerykit config set [--api-key KEY] [--postgres-url URL] [--project-name NAME]
+sourcerykit config set [--postgres-url URL] [--project-name NAME]
 ```
 
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--api-key` | Set `PROVABLY_API_KEY` |
 | `--postgres-url` | Set `SOURCERYKIT_POSTGRES_URL` |
 | `--project-name` | Set `SOURCERYKIT_PROJECT_NAME` |
 
 **Input:** Interactive checkbox to select variables to update:
-- `PROVABLY_API_KEY` (global)
 - `SOURCERYKIT_POSTGRES_URL` (local)
 - `SOURCERYKIT_PROJECT_NAME` (local)
 
@@ -598,7 +594,7 @@ No trace found matching prefix "abc123".
 | Cannot reach Provably API | Network or firewall issue | Check connectivity; verify `SOURCERYKIT_PROVABLY_API_URL` if using a custom endpoint |
 | Missing bootstrap IDs | Incomplete init or corrupted `.env` | Run `sourcerykit doctor --fix` |
 | PostgreSQL connection failed | Wrong URL or DB not reachable | Check `SOURCERYKIT_POSTGRES_URL` in `.env`; ensure the database is publicly accessible |
-| API key invalid | Wrong key or expired | Run `sourcerykit init` to re-authenticate and fetch a new key |
+| Session expired | Access/refresh token expired or revoked | Run `sourcerykit init` to re-authenticate |
 | Config not loading | Missing global or local config | Run `sourcerykit doctor` to identify which values are missing |
 | Sandbox expired | Sandbox TTL exceeded | Auto-recreated on next bootstrap; or run `sourcerykit sandbox create` |
 | Sandbox not found | No sandbox created for this org | Run `sourcerykit init --sandbox` or `sourcerykit sandbox create` |

--- a/docs/getting_started/cli.md
+++ b/docs/getting_started/cli.md
@@ -39,7 +39,7 @@ SourceryKit stores configuration at two levels:
 
 | Config | Location | Scope | Stores |
 |--------|----------|-------|--------|
-| Global | `typer.get_app_dir("sourcerykit")` (OS application directory) | User-level | `api_key`, `org_id`, `token`, `email` |
+| Global | `typer.get_app_dir("sourcerykit")` (OS application directory) | User-level | `api_key`, `org_id`, `token`, `refresh_token`, `email` |
 | Local | `./.env` (project directory) | Project-level | `SOURCERYKIT_POSTGRES_URL`, `SOURCERYKIT_PROJECT_NAME`, bootstrap IDs |
 
 Global config is shared across all projects. Local config is project-specific and should be added to `.gitignore`.
@@ -50,43 +50,36 @@ Global config is shared across all projects. Local config is project-specific an
 
 ### `sourcerykit init`
 
-Setup wizard for account creation/login, database linking, and project initialization.
+Setup wizard for browser login (OAuth), database linking, and project initialization.
 
 ```bash
-sourcerykit init [--register] [--email EMAIL] [--password PASSWORD] [--postgres-url URL] [--project-name NAME] [--sandbox]
+sourcerykit init [--postgres-url URL] [--project-name NAME] [--sandbox]
 ```
 
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--register` | Create a new account (requires `--email` and `--password`) |
-| `--email` | Account email |
-| `--password` | Account password |
 | `--postgres-url` | Full `postgresql://` URL |
 | `--project-name` | Project name |
 | `--sandbox` | Use a hosted sandbox database instead of your own PostgreSQL |
 
 > [!NOTE]
-> `--email` and `--password` must be used together. Use `--register` to create a new account, or omit it to log in with an existing account. Registration requires email verification before you can log in.
+> Login is **browser-based OAuth** (PKCE). Passing any flag opens the browser login once,
+> then continues non-interactively with the given options.
 
 **What it does:**
-- Account setup (register or login)
+- Account login (browser OAuth)
 - API key retrieval
 - Sandbox database provisioning (or custom PostgreSQL with `--postgres-url`)
 - Project naming
 - Bootstrap resource creation
 
-**Input:** Interactive prompts for email, password, database, and project name.
+**Input:** Browser-based OAuth login; then database and project name prompts (or flags).
 
 ```bash
 Welcome to the SourceryKit Wizard! How would you like to proceed?
-❯ Log in with an existing account
-  Create a new account
+❯ Log in with browser (OAuth)
   Exit
-
-🔐 Log in to your account
-Email address: user@example.com
-Password: ********
 
 🗄️  Database setup
 How would you like to set up your database?
@@ -97,29 +90,17 @@ How would you like to set up your database?
 Project name: my-project
 ```
 
-**Non-interactive registration:**
-```bash
-sourcerykit init --register --email user@example.com --password secret
-# → "📧 Verification email sent"
-# → Verify your account, then run:
-# →   sourcerykit init --email user@example.com --password secret"
-```
-
-**Non-interactive login + setup:**
+**Browser login + sandbox (opens the browser once, then continues):**
 ```bash
 sourcerykit init \
-  --email user@example.com \
-  --password secret \
-  --postgres-url "postgresql://user:pass@host:5432/db" \
+  --sandbox \
   --project-name my-project
 ```
 
-**Non-interactive login + sandbox:**
+**Browser login + own database:**
 ```bash
 sourcerykit init \
-  --email user@example.com \
-  --password secret \
-  --sandbox \
+  --postgres-url "postgresql://user:pass@host:5432/db" \
   --project-name my-project
 ```
 

--- a/docs/getting_started/onboarding.md
+++ b/docs/getting_started/onboarding.md
@@ -47,7 +47,8 @@ Full command reference (`init`, `doctor`, `endpoints`, `config`, `trace`): [cli.
 `init` stores credentials at two levels (see [cli.md](https://provably.ai/docs/getting_started/cli) for the full table):
 
 - **Global config** (OS application directory, shared across projects): the Provably
-  **API key** and **organisation id** — issued together at login; never hand-write them.
+  OAuth **access/refresh tokens** and the **organisation id** — issued together at
+  login; never hand-write them.
 - **Project `.env`**: `SOURCERYKIT_POSTGRES_URL` (the database SourceryKit records
   intercepts in — set automatically for sandbox users), `SOURCERYKIT_PROJECT_NAME`, and
   the bootstrap resource ids (`SOURCERYKIT_MIDDLEWARE_ID`, `…_DATABASE_ID`, `…_SCHEMA_ID`,
@@ -67,7 +68,8 @@ with `sourcerykit doctor` (add `--fix`).
 Already have credentials? Environment variables override the stored config:
 
 ```bash
-export PROVABLY_API_KEY="..."
+export PROVABLY_ACCESS_TOKEN="..."
+export PROVABLY_REFRESH_TOKEN="..."
 export SOURCERYKIT_ORG_ID="..."
 export SOURCERYKIT_POSTGRES_URL="postgresql://user:password@host:5432/db"
 ```

--- a/docs/getting_started/onboarding.md
+++ b/docs/getting_started/onboarding.md
@@ -5,11 +5,12 @@ This is the **first** step — nothing else works until the credentials below ex
 
 ## ⚠️ One human step
 
-Registration triggers an **email verification link that only a human can click** — that is
-the single step an automated agent cannot do. Everything else (register, login, database
-link, project setup) runs non-interactively. If you are an agent: **prefer the
-`sourcerykit init` CLI over hand-writing config**, run the setup below yourself, and ask a
-human only for the verification click.
+Login is **browser-based OAuth**. The only step an automated agent cannot do is the
+browser sign-in — a human opens the consent page, signs in (or creates an account on
+the Provably web app), and approves. Everything else (database link, project setup)
+runs automatically. If you are an agent: **prefer the `sourcerykit init` CLI over
+hand-writing config**, run the setup below yourself, and ask a human only to complete
+the browser login.
 
 ## Setup
 
@@ -17,19 +18,12 @@ human only for the verification click.
 pip install sourcerykit
 ```
 
-Non-interactive (agents and scripts):
-
 ```bash
-# 1. register (skip if the account exists) — triggers the verification email
-sourcerykit init --register --email you@example.com --password ...
+# Browser OAuth login (one human step). With --sandbox/--project-name the wizard
+# continues automatically after the browser login completes.
+sourcerykit init --sandbox --project-name my-app
 
-# 2. a HUMAN clicks the verification link in the email
-
-# 3. log in + create sandbox + name the project
-sourcerykit init --email you@example.com --password ... \
-  --sandbox --project-name my-app
-
-# 4. verify everything works
+# verify everything works
 sourcerykit doctor
 ```
 
@@ -38,13 +32,13 @@ sourcerykit doctor
 > `--postgres-url postgresql://user:pass@host:5432/db`.
 
 > [!NOTE]
-> A brand-new account has no organization, so step 3 auto-creates one and stays fully
-> non-interactive. If the account already belongs to **multiple** orgs, `init` prompts you
-> to choose — use a single-org account to keep it scriptable.
+> A brand-new account has no organization, so `init` auto-creates one. If the account
+> already belongs to **multiple** orgs, `init` prompts you to choose — use a
+> single-org account to keep it scriptable.
 
-Interactive: run `sourcerykit init` with no flags and follow the wizard — same steps,
-prompted (sign up or log in → verify email → create a hosted sandbox → name the project
-→ credentials stored). You can also choose to link your own PostgreSQL instead.
+Interactive: run `sourcerykit init` with no flags and follow the wizard — the browser
+login opens, then you create a hosted sandbox and name the project. You can also choose
+to link your own PostgreSQL instead.
 
 Full command reference (`init`, `doctor`, `endpoints`, `config`, `trace`): [cli.md](https://provably.ai/docs/getting_started/cli).
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -4,6 +4,7 @@ Upgrade guides for SourceryKit releases. Each guide covers breaking changes, new
 
 | Version | Action | Guide |
 |---|---|---|
+| [Unreleased](unreleased/unreleased.md) | `sourcerykit init` | Breaking: API key → OAuth tokens; browser-only login |
 | [v1.1](v1_1/v1_1.md) | `sourcerykit upgrade` | Breaking: `reasoning` → `answer`; schema change (traces.answer) |
 | [v1.0.1](https://github.com/ProvablyAI/sourcerykit/blob/main/CHANGELOG.md#101) | `pip install --upgrade sourcerykit` | No schema change |
 | [v1.0](v1_0/v1_0.md) | `sourcerykit upgrade` | Full migration from previous versions |

--- a/docs/migrations/unreleased/unreleased.md
+++ b/docs/migrations/unreleased/unreleased.md
@@ -1,0 +1,54 @@
+# Migrating to the unreleased version
+
+<!-- When cutting the release, rename this directory to the version (e.g. `v1_2/v1_2.md`) and update the link in `docs/migrations/README.md` and `CHANGELOG.md`. -->
+
+## Breaking change: user API key replaced by OAuth tokens
+
+The user API key is gone. The SDK authenticates with the OAuth access token (auto-refreshed via the refresh token), and the handoff verify path uses the per-collection **integration key** instead of the user key.
+
+| Previous | New | Notes |
+|---|---|---|
+| `PROVABLY_API_KEY` | `PROVABLY_ACCESS_TOKEN` | Issued by `sourcerykit init` (browser OAuth) |
+| — | `PROVABLY_REFRESH_TOKEN` | Optional in env; rotated automatically by the SDK |
+
+If you construct `Settings` manually, `api_key` is now `access_token` (plus optional `refresh_token`):
+
+```python
+# Previous
+Settings(api_key="zk-...", org_id=...)
+
+# New
+Settings(access_token="...", org_id=...)
+```
+
+Other changes:
+- `sourcerykit init` no longer mints a user API key.
+- `sourcerykit config set --api-key` and the `PROVABLY_API_KEY` display in `config list` are removed.
+- New optional `SOURCERYKIT_TOKEN_STORE` — an embedded app can point token rotation at its own `.env` instead of the global config.
+
+### Action required
+
+Re-run the wizard — the old global config holds `api_key` but no `token`:
+
+```bash
+sourcerykit init
+```
+
+## Breaking change: OAuth browser-only login
+
+`sourcerykit init` no longer accepts `--register`, `--email`, or `--password`. Login is browser-based OAuth (PKCE) only; new accounts are created on the Provably web app during the browser login. `--postgres-url`, `--project-name`, and `--sandbox` still work non-interactively after the one-time browser login.
+
+## Also in this release
+
+- **Idempotent integration bootstrap** — re-running `init`/`doctor --fix` reuses the existing integration (exact collection match) via the new `POST /organizations/{org_id}/integrations/ensure` endpoint, instead of minting a duplicate key and shadow user.
+
+## Schema
+
+No database schema changes.
+
+## Upgrade
+
+```bash
+pip install --upgrade sourcerykit
+sourcerykit init   # re-authenticate (browser OAuth)
+```

--- a/docs/pillars/handoff.md
+++ b/docs/pillars/handoff.md
@@ -29,7 +29,7 @@ Each `ClaimedValue` in that list has three string fields — nothing else:
 
 
 ## Anatomy of the payload_data
-The `build_handoff_payload` function accepts a structured `payload_data` dictionary. Other runtime fields—such as network intercepts, organization IDs, and API keys—are resolved automatically by the SDK during compilation.
+The `build_handoff_payload` function accepts a structured `payload_data` dictionary. Other runtime fields—such as network intercepts, organization IDs, and the integration key—are resolved automatically by the SDK during compilation.
 
 > [!NOTE]
 > The fields below represent a complete and exhaustive view of the parameters you can manually configure. Any schema fields omitted from these tables are managed entirely by the SDK lifecycle.

--- a/src/sourcerykit/bootstrap/_cache.py
+++ b/src/sourcerykit/bootstrap/_cache.py
@@ -110,7 +110,7 @@ class ProvablyBootstrapCache:
     async def _resolve_integration_key(self) -> str:
         if self.collection_id is None:
             raise SourceryKitBootstrapError("collection_id is not set; _resolve_collection() must succeed first")
-        _, key = await service.create_integration(self.collection_id)
+        _, key = await service.ensure_integration(self.collection_id)
         return key
 
 

--- a/src/sourcerykit/cli/config.py
+++ b/src/sourcerykit/cli/config.py
@@ -1,5 +1,3 @@
-import re
-
 import questionary
 import typer
 
@@ -7,12 +5,11 @@ from sourcerykit.cli.init import clear_auth_caches, create_db_tables, run_provab
 from sourcerykit.cli.utils import (
     console,
     mask_postgres_url,
-    mask_secret,
     prompt_postgres_url_with_retry,
     prompt_project_name,
     require_settings,
 )
-from sourcerykit.config import get_settings, load_local_env, save_app_dir_config, save_local_env
+from sourcerykit.config import get_settings, load_local_env, save_local_env
 
 config = typer.Typer(no_args_is_help=True)
 
@@ -22,9 +19,8 @@ def list(show_key: bool = typer.Option(False, "--show-key", help="show secrets i
     """Pretty print the active configuration (global + local)."""
     settings = require_settings()
 
-    api_key_display = settings.api_key if show_key else mask_secret(settings.api_key)
     console.print("\n📋 [bold]Global Config[/bold] \n")
-    console.print(f"[cyan]PROVABLY_API_KEY[/cyan]       = [yellow]'{api_key_display}'[/yellow]")
+    console.print(f"[cyan]SOURCERYKIT_ORG_ID[/cyan]       = [yellow]'{settings.org_id}'[/yellow]")
 
     pg_display = settings.postgres_url if show_key else mask_postgres_url(settings.postgres_url)
 
@@ -37,18 +33,15 @@ def list(show_key: bool = typer.Option(False, "--show-key", help="show secrets i
 
 @config.command()
 def set(
-    api_key: str | None = typer.Option(None, "--api-key", help="set PROVABLY_API_KEY"),
     postgres_url: str | None = typer.Option(None, "--postgres-url", help="set SOURCERYKIT_POSTGRES_URL"),
     project_name: str | None = typer.Option(None, "--project-name", help="set SOURCERYKIT_PROJECT_NAME"),
 ) -> None:
     """Interactively set or update configuration variables."""
-    has_flags = api_key is not None or postgres_url is not None or project_name is not None
+    has_flags = postgres_url is not None or project_name is not None
     console.print("\n⚙️  [bold]SourceryKit Configuration Setup[/bold]\n")
 
     if has_flags:
         choices = []
-        if api_key is not None:
-            choices.append("PROVABLY_API_KEY (global)")
         if postgres_url is not None:
             choices.append("SOURCERYKIT_POSTGRES_URL (local)")
         if project_name is not None:
@@ -57,7 +50,6 @@ def set(
         choices = questionary.checkbox(
             "Which configuration variables would you like to update?",
             choices=[
-                questionary.Choice("PROVABLY_API_KEY (global)", checked=False),
                 questionary.Choice("SOURCERYKIT_POSTGRES_URL (local)", checked=False),
                 questionary.Choice("SOURCERYKIT_PROJECT_NAME (local)", checked=False),
             ],
@@ -68,23 +60,6 @@ def set(
             return
 
     # --- Collect inputs ---
-
-    api_key_val = None
-    if "PROVABLY_API_KEY (global)" in choices:
-        if api_key is not None:
-            api_key_val = api_key.strip()
-        else:
-            api_key_val = questionary.password("Enter your PROVABLY_API_KEY:").ask()
-            if api_key_val is not None:
-                api_key_val = api_key_val.strip()
-
-        if api_key_val is not None:
-            if not api_key_val:
-                console.print("[red]❌ API key cannot be empty.[/red]")
-                api_key_val = None
-            elif not re.fullmatch(r"zk-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", api_key_val):
-                console.print("[red]❌ API key must match format zk-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx[/red]")
-                api_key_val = None
 
     postgres_url_val = None
     postgres_changed = False
@@ -111,9 +86,6 @@ def set(
             console.print("[yellow]Same name — no change.[/yellow]")
 
     # --- Save config ---
-
-    if api_key_val:
-        save_app_dir_config(api_key=api_key_val)
 
     local_updates: dict[str, str] = {}
     if postgres_url_val:

--- a/src/sourcerykit/cli/doctor.py
+++ b/src/sourcerykit/cli/doctor.py
@@ -13,38 +13,25 @@ from sourcerykit.provably.auth_service import auth_service
 from sourcerykit.provably.service import service
 
 
-def _check_provably_reachability(settings: Settings) -> tuple[bool, str]:
-    """Ensure Provably API is reachable before any other checks."""
-    if not settings.api_key:
-        return False, "PROVABLY_API_KEY is missing — run 'sourcerykit init'"
-    try:
-        asyncio.run(auth_service.list_organizations())
-        return True, "Provably API reachable"
-    except ProvablyConnectionError:
-        return False, "Cannot reach Provably API — check your connection"
-    except Exception as e:
-        return False, f"Provably API check failed: {e}"
-
-
-def _check_api_key_and_org(settings: Settings) -> tuple[bool, str]:
-    """Validate API key and org_id in one call (list_organizations uses API key)."""
-    if not settings.api_key:
-        return False, "PROVABLY_API_KEY is missing — run 'sourcerykit init'"
+def _check_token_and_org(settings: Settings) -> tuple[bool, str]:
+    """Validate access token and org_id in one call (list_organizations uses the token)."""
+    if not settings.access_token:
+        return False, "Access token is missing — run 'sourcerykit init'"
 
     try:
         orgs = asyncio.run(auth_service.list_organizations())
     except ProvablyUnauthorizedError:
-        return False, "API key is invalid or expired — run 'sourcerykit init'"
+        return False, "Session expired — run 'sourcerykit init'"
     except ProvablyConnectionError:
         return False, "Cannot reach Provably API (network error)"
     except Exception as e:
-        return False, f"API key check failed: {e}"
+        return False, f"Session check failed: {e}"
 
     org_ids = [str(o.get("id", "")) for o in orgs]
     if str(settings.org_id) not in org_ids:
         return False, f"Org ID {settings.org_id} not found — run 'sourcerykit init'"
 
-    return True, f"API key valid, org found ({len(orgs)} org(s))"
+    return True, f"Session valid, org found ({len(orgs)} org(s))"
 
 
 def _check_database(settings: Settings) -> tuple[bool, str]:
@@ -136,7 +123,7 @@ def _run_deep_check_collection_and_ids(settings: Settings) -> tuple[bool, str]:
     try:
         return asyncio.run(_deep_check_collection_and_ids(settings))
     except ProvablyUnauthorizedError:
-        return False, "API key expired — run 'sourcerykit init'"
+        return False, "Session expired — run 'sourcerykit init'"
     except ProvablyConnectionError:
         return False, "Cannot reach Provably API (network error)"
     except Exception as e:
@@ -147,7 +134,7 @@ def _run_deep_check_integration(settings: Settings) -> tuple[bool, str]:
     try:
         return asyncio.run(_deep_check_integration(settings))
     except ProvablyUnauthorizedError:
-        return False, "API key expired — run 'sourcerykit init'"
+        return False, "Session expired — run 'sourcerykit init'"
     except ProvablyConnectionError:
         return False, "Cannot reach Provably API (network error)"
     except Exception as e:
@@ -166,8 +153,7 @@ def run_doctor(fix: bool = False) -> None:
         return
 
     checks: list[tuple[str, Callable[[], tuple[bool, str]]]] = [
-        ("Provably API", lambda: _check_provably_reachability(settings)),
-        ("API key + org", lambda: _check_api_key_and_org(settings)),
+        ("Session + org", lambda: _check_token_and_org(settings)),
         ("Database", lambda: _check_database(settings)),
         ("Project name", lambda: _check_project_name(settings)),
         ("Bootstrap IDs", lambda: _check_bootstrap_ids(settings)),

--- a/src/sourcerykit/cli/init.py
+++ b/src/sourcerykit/cli/init.py
@@ -196,16 +196,7 @@ def _execute_post_auth_phases(
     if not org_id:
         return False
 
-    try:
-        api_key = asyncio.run(service.get_api_key(token))
-    except ProvablyConnectionError as e:
-        console.print(f"[red]❌ Error retrieving API key: {e}[/red]")
-        return False
-    except Exception as e:
-        console.print(f"[red]❌ Key exchange failed: {e}[/red]")
-        return False
-
-    save_app_dir_config(api_key=api_key, org_id=org_id)
+    save_app_dir_config(org_id=org_id)
     clear_auth_caches()
 
     # --- database ---
@@ -278,7 +269,6 @@ def _execute_post_auth_phases(
 
     console.print("\n[bold green]🎉 SOURCERYKIT SETUP COMPLETE[/bold green]\n")
     console.print(" Global config:")
-    console.print(f"   PROVABLY_API_KEY    = {mask_secret(api_key)}")
     console.print(f"   SOURCERYKIT_ORG_ID  = {org_id}\n")
     console.print(" Local config (.env):")
     console.print(f"   SOURCERYKIT_PROJECT_NAME    = {project_name}")

--- a/src/sourcerykit/cli/init.py
+++ b/src/sourcerykit/cli/init.py
@@ -28,7 +28,7 @@ from sourcerykit.provably._errors import (
 )
 from sourcerykit.provably._http import get_http
 from sourcerykit.provably.auth_service import ProvablyAuthService
-from sourcerykit.provably.oauth_login import browser_login, fetch_user_email
+from sourcerykit.provably.oauth_login import browser_login
 from sourcerykit.provably.service import service as provably_service
 
 service = ProvablyAuthService()
@@ -47,8 +47,9 @@ def _run_oauth_browser(
     """
     try:
         console.print("\n[bold]🔐 Browser authentication[/bold]")
+        console.print("Opening browser for authentication...")
         tokens = asyncio.run(browser_login())
-        email = asyncio.run(fetch_user_email(tokens.access_token))
+        email = asyncio.run(service.get_user_email(tokens.access_token))
     except ProvablyConnectionError as e:
         console.print(f"[red]❌ Network error: {e}[/red]")
         return

--- a/src/sourcerykit/cli/init.py
+++ b/src/sourcerykit/cli/init.py
@@ -3,7 +3,6 @@
 import asyncio
 import sys
 import uuid
-from typing import Any
 
 import questionary
 import typer
@@ -22,138 +21,48 @@ from sourcerykit.config import load_app_dir_config, save_app_dir_config, save_lo
 from sourcerykit.db._engine import get_engine
 from sourcerykit.db._schema import ensure_schema
 from sourcerykit.provably._api import get_api as get_main_api
-from sourcerykit.provably._auth_api import Organization, OrganizationType, User
+from sourcerykit.provably._auth_api import Organization, OrganizationType
 from sourcerykit.provably._errors import (
     ProvablyConnectionError,
     ProvablyUnauthorizedError,
 )
 from sourcerykit.provably._http import get_http
 from sourcerykit.provably.auth_service import ProvablyAuthService
+from sourcerykit.provably.oauth_login import browser_login, fetch_user_email
 from sourcerykit.provably.service import service as provably_service
 
 service = ProvablyAuthService()
 
 
-def _collect_register_inputs() -> dict[str, Any]:
-    console.print("\n[bold]🔑 Create your account[/bold]")
-    questions = [
-        {
-            "type": "text",
-            "name": "email",
-            "message": "Email address:",
-            "validate": lambda text: True if len(text.strip()) > 0 else "Email cannot be empty.",
-        },
-        {
-            "type": "password",
-            "name": "password",
-            "message": "Password:",
-            "validate": lambda text: True if len(text.strip()) > 0 else "Password cannot be empty.",
-        },
-    ]
-    return questionary.prompt(questions) or {}
-
-
-# --- Credential collection and account setup ---
-def _run_register(email: str | None = None, password: str | None = None) -> str:
-    """Handles the user registration setup path.
-
-    When *email* and *password* are provided, skips interactive prompts and
-    exits after printing verification instructions (non-interactive mode).
-    """
-    if email and password:
-        register_email = email.strip()
-        user = User(email=register_email, password=password)
-    else:
-        inputs = _collect_register_inputs()
-        if not inputs:
-            return ""
-        register_email = inputs.get("email", "").strip()
-        user = User(email=register_email, password=inputs["password"])
-
-    # --- Create account ---
-    try:
-        console.print("\nCreating your account...")
-        asyncio.run(service.create_account(user))
-        console.print("\n[bold]📧 Verification email sent[/bold]")
-        console.print(" We've sent a verification link to your email inbox.")
-        console.print(" Please check your mail and verify your account to continue.")
-
-        if email and password:
-            console.print("\n[bold]📌 NEXT STEPS:[/bold]")
-            console.print(" 1. Click the link in your email to verify your account.")
-            console.print(" 2. Then run:\n")
-            console.print(f"   sourcerykit init --email {email} --password ******\n")
-            raise typer.Exit()
-
-        console.print("\n[bold]📌 NEXT STEPS:[/bold]")
-        console.print(" 1. Click the link in your email to verify your account.")
-        console.print(" 2. Return here, choose 'Log in', and link your database.\n")
-
-        questionary.press_any_key_to_continue("Press any key to return to the main menu...").ask()
-        return register_email
-
-    except ProvablyUnauthorizedError:
-        console.print(
-            "\n[red]❌ Registration rejected — the email may already be registered or the request was invalid.[/red]"
-        )
-        return ""
-    except ProvablyConnectionError as e:
-        console.print(f"[red]❌ Network error during registration: {e}[/red]")
-        return ""
-
-
-def _run_login(
+def _run_oauth_browser(
     *,
-    prefill_email: str = "",
-    email: str | None = None,
-    password: str | None = None,
     postgres_url: str | None = None,
     project_name: str | None = None,
     sandbox: bool = False,
 ) -> None:
-    """Handles authentication.
+    """OAuth2 browser login, then run the post-auth setup phases.
 
-    When *email* and *password* are provided, skips interactive prompts.
+    Opens the consent page in the browser, fetches the logged-in user's email
+    from ``/api/v1/user/current``, and continues with the database/project setup.
     """
-    if email and password:
-        login_email = email.strip()
-        login_password = password
-    else:
-        console.print("\n[bold]🔐 Log in to your account[/bold]")
-        login_email = questionary.text(
-            message="Email address:",
-            default=prefill_email,
-            validate=lambda text: True if len(text.strip()) > 0 else "Email cannot be empty.",
-        ).ask()
-        if not login_email:
-            return
-
-        login_password = questionary.password(
-            message="Password:",
-            validate=lambda text: True if len(text.strip()) > 0 else "Password cannot be empty.",
-        ).ask()
-        if not login_password:
-            return
-
     try:
-        console.print("\nLogging in...")
-        result = asyncio.run(service.login(User(email=login_email, password=login_password)))
-    except ProvablyUnauthorizedError:
-        console.print("\n[red]❌ Invalid email/password, or your account isn't verified yet.[/red]")
-        console.print("Please check your verification link or try again.")
-        return
+        console.print("\n[bold]🔐 Browser authentication[/bold]")
+        tokens = asyncio.run(browser_login())
+        email = asyncio.run(fetch_user_email(tokens.access_token))
     except ProvablyConnectionError as e:
         console.print(f"[red]❌ Network error: {e}[/red]")
         return
-
-    token = result.get("token") or result.get("access_token", "")
-    if not token:
-        console.print("[red]❌ Login failed: Token missing from API response.[/red]")
+    except Exception as e:
+        console.print(f"[red]❌ Browser login failed: {e}[/red]")
         return
 
-    save_app_dir_config(token=token, email=login_email)
+    save_app_dir_config(token=tokens.access_token, refresh_token=tokens.refresh_token, email=email)
     if _execute_post_auth_phases(
-        token, email=login_email, postgres_url=postgres_url, project_name=project_name, sandbox=sandbox
+        tokens.access_token,
+        email=email,
+        postgres_url=postgres_url,
+        project_name=project_name,
+        sandbox=sandbox,
     ):
         console.print("\n👋 Setup closed. Happy coding!")
         raise typer.Exit()
@@ -381,36 +290,16 @@ def _execute_post_auth_phases(
 
 def config_provably(
     *,
-    register: bool = False,
-    email: str | None = None,
-    password: str | None = None,
     postgres_url: str | None = None,
     project_name: str | None = None,
     sandbox: bool = False,
 ) -> None:
     console.print(logo.print_logo(), "\n\n")
 
-    # Non-interactive registration
-    if register:
-        if not email or not password:
-            console.print("[red]❌ --register requires --email and --password[/red]")
-            raise typer.Exit(code=1)
-        if postgres_url or project_name:
-            console.print(
-                "[red]❌ --postgres-url and --project-name cannot be used with --register (verify email first)[/red]"
-            )
-            raise typer.Exit(code=1)
-        _run_register(email=email, password=password)
+    # Non-interactive: any flag implies a browser login, then continue with the flags.
+    if postgres_url or project_name or sandbox:
+        _run_oauth_browser(postgres_url=postgres_url, project_name=project_name, sandbox=sandbox)
         return
-
-    # Non-interactive login when credentials are provided
-    if email and password:
-        _run_login(
-            email=email, password=password, postgres_url=postgres_url, project_name=project_name, sandbox=sandbox
-        )
-        return
-
-    saved_email = ""
 
     while True:
         global_cfg = load_app_dir_config()
@@ -449,15 +338,14 @@ def config_provably(
                     raise typer.Exit()
             except ProvablyUnauthorizedError:
                 console.print("[yellow]⚠️  Stored session expired. Please log in again.[/yellow]\n")
-                # Clear expired token so next iteration shows Login/Register
+                # Clear expired token so next iteration shows the browser login
                 logout()
                 continue
         else:
             action = questionary.select(
                 message="Welcome to the SourceryKit Wizard! How would you like to proceed?",
                 choices=[
-                    {"name": "Log in with an existing account", "value": "login"},
-                    {"name": "Create a new account", "value": "register"},
+                    {"name": "Log in with browser (OAuth)", "value": "oauth"},
                     {"name": "Exit", "value": "exit"},
                 ],
             ).ask()
@@ -466,7 +354,4 @@ def config_provably(
                 console.print("\n👋 Setup closed. Happy coding!")
                 return
 
-            if action == "register":
-                saved_email = _run_register()
-            else:
-                _run_login(prefill_email=saved_email, sandbox=sandbox)
+            _run_oauth_browser(sandbox=sandbox)

--- a/src/sourcerykit/cli/main.py
+++ b/src/sourcerykit/cli/main.py
@@ -20,23 +20,13 @@ app.add_typer(sandbox, name="sandbox")
 app.add_typer(trace, name="trace")
 
 
-@app.command(help="interactive setup wizard (account, database, project)")
+@app.command(help="interactive setup wizard (browser login, database, project)")
 def init(
-    register: bool = typer.Option(False, "--register", help="create a new account (requires --email and --password)"),
-    email: str | None = typer.Option(None, "--email", help="account email"),
-    password: str | None = typer.Option(None, "--password", help="account password"),
     postgres_url: str | None = typer.Option(None, "--postgres-url", help="full postgres:// URL"),
     project_name: str | None = typer.Option(None, "--project-name", help="project name"),
     sandbox: bool = typer.Option(False, "--sandbox", help="use hosted sandbox database"),
 ) -> None:
-    config_provably(
-        register=register,
-        email=email,
-        password=password,
-        postgres_url=postgres_url,
-        project_name=project_name,
-        sandbox=sandbox,
-    )
+    config_provably(postgres_url=postgres_url, project_name=project_name, sandbox=sandbox)
 
 
 @app.command(help="validate configuration and connectivity")

--- a/src/sourcerykit/cli/utils.py
+++ b/src/sourcerykit/cli/utils.py
@@ -41,9 +41,9 @@ def require_settings() -> Settings:
 
 
 def logout() -> None:
-    """Clear stored session (token + email) from global config."""
+    """Clear stored session (token + email + refresh token) from global config."""
     payload = load_app_dir_config()
-    for key in ("token", "email"):
+    for key in ("token", "email", "refresh_token"):
         payload.pop(key, None)
     CONFIG_FILE.write_text(json.dumps(payload))
     load_app_dir_config.cache_clear()

--- a/src/sourcerykit/config.py
+++ b/src/sourcerykit/config.py
@@ -100,7 +100,11 @@ def load_app_dir_config() -> dict[str, Any]:
 
 # Global config file (user-level config)
 def save_app_dir_config(
-    api_key: str | None = None, org_id: str | None = None, token: str | None = None, email: str | None = None
+    api_key: str | None = None,
+    org_id: str | None = None,
+    token: str | None = None,
+    email: str | None = None,
+    refresh_token: str | None = None,
 ) -> None:
     """Save global configuration (user-level) to the OS app directory."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -114,6 +118,8 @@ def save_app_dir_config(
         payload["token"] = token
     if email is not None:
         payload["email"] = email
+    if refresh_token is not None:
+        payload["refresh_token"] = refresh_token
 
     CONFIG_FILE.write_text(json.dumps(payload))
     os.chmod(CONFIG_FILE, 0o600)

--- a/src/sourcerykit/config.py
+++ b/src/sourcerykit/config.py
@@ -33,11 +33,14 @@ LOCAL_ENV_FILE = Path(".env")
 class Settings:
     """All environment variables consumed by sourcerykit."""
 
-    api_key: str
-    """PROVABLY_API_KEY — Provably API key."""
+    access_token: str
+    """PROVABLY_ACCESS_TOKEN — OAuth access token for the Provably API."""
 
     org_id: uuid.UUID
     """SOURCERYKIT_ORG_ID — Provably organisation ID."""
+
+    refresh_token: str = ""
+    """PROVABLY_REFRESH_TOKEN — OAuth refresh token, rotated on refresh."""
 
     postgres_url: str = ""
     """SOURCERYKIT_POSTGRES_URL — URL for the agent's Postgres database."""
@@ -65,8 +68,8 @@ class Settings:
     def __post_init__(self) -> None:
         """Validate required fields after initialization."""
         missing = []
-        if not self.api_key:
-            missing.append("PROVABLY_API_KEY")
+        if not self.access_token:
+            missing.append("PROVABLY_ACCESS_TOKEN")
         if not self.org_id or self.org_id == UUID_NIL:
             missing.append("SOURCERYKIT_ORG_ID")
 
@@ -100,7 +103,6 @@ def load_app_dir_config() -> dict[str, Any]:
 
 # Global config file (user-level config)
 def save_app_dir_config(
-    api_key: str | None = None,
     org_id: str | None = None,
     token: str | None = None,
     email: str | None = None,
@@ -110,8 +112,6 @@ def save_app_dir_config(
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     payload = load_app_dir_config()
 
-    if api_key is not None:
-        payload["api_key"] = api_key
     if org_id is not None:
         payload["org_id"] = org_id
     if token is not None:
@@ -192,7 +192,8 @@ def get_settings() -> Settings:
             return None
 
     return Settings(
-        api_key=_url("PROVABLY_API_KEY", "api_key"),
+        access_token=_url("PROVABLY_ACCESS_TOKEN", "token"),
+        refresh_token=_url("PROVABLY_REFRESH_TOKEN", "refresh_token"),
         org_id=_org_id,
         postgres_url=_local_resolve("SOURCERYKIT_POSTGRES_URL", "SOURCERYKIT_POSTGRES_URL"),
         project_name=_local_resolve("SOURCERYKIT_PROJECT_NAME", "SOURCERYKIT_PROJECT_NAME"),
@@ -211,7 +212,7 @@ def get_settings() -> Settings:
 def get_bootstrap_settings() -> str:
     """Return the Provably API URL without requiring full settings validation.
 
-    Safe to call before ``api_key``, ``org_id``, or ``postgres_url`` are configured.
+    Safe to call before ``access_token``, ``org_id``, or ``postgres_url`` are configured.
     """
     raw = (os.getenv("SOURCERYKIT_PROVABLY_API_URL") or "").strip().rstrip("/")
     if not raw:

--- a/src/sourcerykit/config.py
+++ b/src/sourcerykit/config.py
@@ -18,7 +18,7 @@ from sourcerykit.errors import SourceryKitConfigError
 UUID_NIL = getattr(uuid, "NIL", uuid.UUID(int=0))
 
 DEFAULT_PROVABLY_API_URL = "https://api.provably.ai"
-DEFAULT_PROVABLY_APP_URL = "https://app.provably.ai"
+DEFAULT_PROVABLY_APP_URL = "https://api.provably.ai"
 DEFAULT_PROVABLY_MCP_URL = "https://mcp.provably.ai"
 
 

--- a/src/sourcerykit/evaluator/evaluator.py
+++ b/src/sourcerykit/evaluator/evaluator.py
@@ -2,7 +2,6 @@ import asyncio
 import uuid
 from typing import Any
 
-from sourcerykit.config import get_settings
 from sourcerykit.db._engine import get_engine
 from sourcerykit.db._traces import update_trace_intercept_outcome
 from sourcerykit.errors import SourceryKitError, SourceryKitStorageError
@@ -19,11 +18,7 @@ _log = get_logger(__name__)
 
 async def evaluate_handoff(*, payload: HandoffPayload) -> dict[str, Any]:
     """Validates trusted endpoints and verifies cryptographic proof loops for all payload claims."""
-
-    # TODO: Refactor.
-    # Not a good idea to pass the API key via the payload (api_key = payload.integration_api_key)
-    # Use a new generated integration apikey with limited access
-    api_key = get_settings().api_key
+    integration_api_key = payload.integration_api_key
 
     query_ids = [claim.query_id for claim in payload.claims]
 
@@ -32,7 +27,7 @@ async def evaluate_handoff(*, payload: HandoffPayload) -> dict[str, Any]:
             # Overlap the endpoint trust check (DB) with proof verification submission (HTTP)
             await asyncio.gather(
                 verify_claim_endpoints(payload),
-                asyncio.gather(*(service.verify_proof(qid, api_key) for qid in query_ids)),
+                asyncio.gather(*(service.verify_proof(qid, integration_api_key) for qid in query_ids)),
             )
     except (ValueError, SourceryKitError) as e:
         return {"outcome": Outcome.CAUGHT, "per_claim": [], "errors": [f"trust gate: {e}"]}
@@ -43,7 +38,7 @@ async def evaluate_handoff(*, payload: HandoffPayload) -> dict[str, Any]:
     with provably_self_egress():
         # Wait for all proof verifications concurrently
         verification_results = await asyncio.gather(
-            *(service.wait_for_proof_verification(qid, api_key) for qid in query_ids),
+            *(service.wait_for_proof_verification(qid, integration_api_key) for qid in query_ids),
             return_exceptions=True,
         )
 

--- a/src/sourcerykit/provably/_api.py
+++ b/src/sourcerykit/provably/_api.py
@@ -242,9 +242,13 @@ class ProvablyAPI:
     # Integrations
     # ------------------------------------------------------------------
 
-    async def create_integration(self, body: dict[str, Any]) -> dict[str, Any]:
+    async def ensure_integration(self, body: dict[str, Any]) -> dict[str, Any]:
         """
-        Register a new external integration for the configured org.
+        Idempotent get-or-create an integration for the configured org.
+
+        Reuses an existing enabled integration with the same name linked to the
+        exact requested collections, returning its full key instead of minting a
+        duplicate.
 
         Args:
             body: The integration registration payload.
@@ -252,7 +256,7 @@ class ProvablyAPI:
         Returns:
             dict[str, Any]: The raw JSON response from the API.
         """
-        path = f"{self._org_path()}/integrations"
+        path = f"{self._org_path()}/integrations/ensure"
 
         result: dict[str, Any] = await get_http().post(path, body)
         return result
@@ -270,17 +274,6 @@ class ProvablyAPI:
         path = f"{self._org_path()}/integrations"
         params = {"query": query} if query is not None else None
         result: list[dict[str, Any]] = await get_http().get(path, params=params)
-        return result
-
-    async def get_integration_by_id(self, integration_id: uuid.UUID) -> dict[str, Any]:
-        """
-        Get integration by id.
-
-        Returns:
-            dict[str, Any]: The raw JSON response from the API.
-        """
-        path = f"{self._org_path()}/integrations/{integration_id}"
-        result: dict[str, Any] = await get_http().get(path)
         return result
 
     # ------------------------------------------------------------------

--- a/src/sourcerykit/provably/_auth_api.py
+++ b/src/sourcerykit/provably/_auth_api.py
@@ -1,10 +1,12 @@
-"""Provably Auth API — API key and organisation endpoints.
+"""Provably Auth API — OAuth tokens, user, API key and organisation endpoints.
 
-:class:`ProvablyAuthAPI` covers two resource groups:
+:class:`ProvablyAuthAPI` covers four resource groups:
+- **OAuth** — exchange an authorization code and rotate refresh tokens
+- **User** — retrieve the current authenticated user
 - **API Key** — retrieve the API key for the authenticated user
 - **Organisations** — create and list organisations
 
-Authentication itself is OAuth browser login; see
+The browser OAuth flow itself lives in
 :mod:`sourcerykit.provably.oauth_login`.
 """
 
@@ -14,6 +16,19 @@ from enum import StrEnum
 from typing import Any
 
 from sourcerykit.provably._http import ProvablyHTTPClient
+
+OAUTH_CLIENT_ID = "sourcerykit-cli"
+OAUTH_SCOPE = "read write"
+LOOPBACK_PORT = 8910
+REDIRECT_URI = f"http://127.0.0.1:{LOOPBACK_PORT}/callback"
+
+
+@dataclass(slots=True)
+class OAuthTokens:
+    """Tokens issued by the OAuth token endpoint."""
+
+    access_token: str
+    refresh_token: str | None
 
 
 class OrganizationType(StrEnum):
@@ -52,6 +67,78 @@ class ProvablyAuthAPI:
 
     def _org_path(self) -> str:
         return "/api/v1/organizations"
+
+    # ------------------------------------------------------------------
+    # OAuth
+    # ------------------------------------------------------------------
+
+    async def exchange_code(self, code: str, verifier: str) -> dict[str, Any]:
+        """
+        Exchange an authorization code for tokens (public client, no secret).
+
+        Args:
+            code: The authorization code from the redirect.
+            verifier: The PKCE code verifier.
+
+        Returns:
+            dict[str, Any]: The raw JSON response (contains ``access_token``
+            and optionally ``refresh_token``).
+        """
+        path = "/api/v1/auth/oauth/token"
+
+        result: dict[str, Any] = await self._http.post_form(
+            path,
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+                "client_id": OAUTH_CLIENT_ID,
+                "code_verifier": verifier,
+            },
+        )
+        return result
+
+    async def refresh_tokens(self, refresh_token: str) -> dict[str, Any]:
+        """
+        Rotate tokens: exchange a refresh token for a new access+refresh pair.
+
+        Args:
+            refresh_token: The refresh token to redeem.
+
+        Returns:
+            dict[str, Any]: The raw JSON response (contains ``access_token``
+            and optionally ``refresh_token``).
+        """
+        path = "/api/v1/auth/oauth/refresh"
+
+        result: dict[str, Any] = await self._http.post_form(
+            path,
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": OAUTH_CLIENT_ID,
+            },
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # User
+    # ------------------------------------------------------------------
+
+    async def get_current_user(self, token: str) -> dict[str, Any]:
+        """
+        Retrieve the current authenticated user.
+
+        Args:
+            token: OAuth access token (Bearer).
+
+        Returns:
+            dict[str, Any]: The raw JSON response from the API (contains ``email``).
+        """
+        path = f"{self._user_path()}/current"
+
+        result: dict[str, Any] = await self._http.get(path, token=token)
+        return result
 
     # ------------------------------------------------------------------
     # API KEY

--- a/src/sourcerykit/provably/_auth_api.py
+++ b/src/sourcerykit/provably/_auth_api.py
@@ -1,23 +1,19 @@
-"""Provably Auth API — account, session and organisation endpoints.
+"""Provably Auth API — API key and organisation endpoints.
 
-:class:`ProvablyAuthAPI` covers three resource groups:
-- **Auth** — register a new account and log in
+:class:`ProvablyAuthAPI` covers two resource groups:
 - **API Key** — retrieve the API key for the authenticated user
 - **Organisations** — create and list organisations
+
+Authentication itself is OAuth browser login; see
+:mod:`sourcerykit.provably.oauth_login`.
 """
 
 import functools
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
 from sourcerykit.provably._http import ProvablyHTTPClient
-
-
-@dataclass(slots=True)
-class User:
-    email: str
-    password: str
 
 
 class OrganizationType(StrEnum):
@@ -51,45 +47,11 @@ class ProvablyAuthAPI:
     def __init__(self) -> None:
         self._http = ProvablyHTTPClient(pre_auth=True)
 
-    def _auth_path(self) -> str:
-        return "/api/v1/auth"
-
     def _user_path(self) -> str:
         return "/api/v1/user"
 
     def _org_path(self) -> str:
         return "/api/v1/organizations"
-
-    # ------------------------------------------------------------------
-    # Auth
-    # ------------------------------------------------------------------
-
-    async def create_account(self, user: User) -> None:
-        """
-        Register a new account.
-
-        Args:
-            user: The user credentials.
-        """
-        path = f"{self._auth_path()}/register"
-
-        await self._http.post(path, asdict(user))
-        return
-
-    async def login(self, user: User) -> dict[str, Any]:
-        """
-        Authenticate with email and password.
-
-        Args:
-            user: The user credentials.
-
-        Returns:
-            dict[str, Any]: The raw JSON response from the API (contains ``token``).
-        """
-        path = f"{self._auth_path()}/login"
-
-        result: dict[str, Any] = await self._http.post(path, asdict(user))
-        return result
 
     # ------------------------------------------------------------------
     # API KEY

--- a/src/sourcerykit/provably/_auth_api.py
+++ b/src/sourcerykit/provably/_auth_api.py
@@ -1,9 +1,8 @@
 """Provably Auth API — OAuth tokens, user, API key and organisation endpoints.
 
-:class:`ProvablyAuthAPI` covers four resource groups:
+:class:`ProvablyAuthAPI` covers three resource groups:
 - **OAuth** — exchange an authorization code and rotate refresh tokens
 - **User** — retrieve the current authenticated user
-- **API Key** — retrieve the API key for the authenticated user
 - **Organisations** — create and list organisations
 
 The browser OAuth flow itself lives in
@@ -136,25 +135,6 @@ class ProvablyAuthAPI:
             dict[str, Any]: The raw JSON response from the API (contains ``email``).
         """
         path = f"{self._user_path()}/current"
-
-        result: dict[str, Any] = await self._http.get(path, token=token)
-        return result
-
-    # ------------------------------------------------------------------
-    # API KEY
-    # ------------------------------------------------------------------
-
-    async def get_api_key(self, token: str) -> dict[str, Any]:
-        """
-        Retrieve the API key for the authenticated user.
-
-        Args:
-            token: JWT Bearer token obtained from ``login``.
-
-        Returns:
-            dict[str, Any]: The raw JSON response from the API (contains ``api_key``).
-        """
-        path = f"{self._user_path()}/key"
 
         result: dict[str, Any] = await self._http.get(path, token=token)
         return result

--- a/src/sourcerykit/provably/_http.py
+++ b/src/sourcerykit/provably/_http.py
@@ -3,9 +3,11 @@
 import asyncio
 import functools
 import json
+import os
 from typing import Any
 
 import httpx
+from dotenv import set_key
 
 from sourcerykit.config import (
     CONFIG_FILE,
@@ -13,12 +15,51 @@ from sourcerykit.config import (
     get_bootstrap_settings,
     get_settings,
     load_app_dir_config,
+    load_local_env,
     save_app_dir_config,
 )
 from sourcerykit.intercept._self_egress import provably_self_egress
 from sourcerykit.logger import get_logger
 
 _log = get_logger(__name__)
+
+
+def _token_store() -> str | None:
+    """Return the app's token-store path (SOURCERYKIT_TOKEN_STORE) or None for global JSON.
+
+    Resolved per-call so the app can set it at startup regardless of import order.
+    """
+    return os.getenv("SOURCERYKIT_TOKEN_STORE") or None
+
+
+def _persist_tokens(access_token: str, refresh_token: str | None) -> None:
+    """Persist rotated tokens to the configured store (app .env or global JSON)."""
+    store = _token_store()
+    if store:
+        set_key(store, "PROVABLY_ACCESS_TOKEN", access_token)
+        set_key(store, "PROVABLY_REFRESH_TOKEN", refresh_token or "")
+        os.environ["PROVABLY_ACCESS_TOKEN"] = access_token
+        if refresh_token:
+            os.environ["PROVABLY_REFRESH_TOKEN"] = refresh_token
+        load_local_env.cache_clear()
+    else:
+        save_app_dir_config(token=access_token, refresh_token=refresh_token)
+    get_settings.cache_clear()
+
+
+def _clear_refresh_token() -> None:
+    """Drop the stored refresh token from the configured store."""
+    store = _token_store()
+    if store:
+        set_key(store, "PROVABLY_REFRESH_TOKEN", "")
+        os.environ.pop("PROVABLY_REFRESH_TOKEN", None)
+        load_local_env.cache_clear()
+    else:
+        payload = load_app_dir_config()
+        payload.pop("refresh_token", None)
+        CONFIG_FILE.write_text(json.dumps(payload))
+        load_app_dir_config.cache_clear()
+    get_settings.cache_clear()
 
 
 async def _refresh_session() -> str | None:
@@ -29,21 +70,17 @@ async def _refresh_session() -> str | None:
     """
     from sourcerykit.provably.auth_service import auth_service
 
-    refresh = load_app_dir_config().get("refresh_token")
+    refresh = get_settings().refresh_token
     if not refresh:
         return None
     try:
         tokens = await auth_service.refresh_tokens(str(refresh))
     except Exception:
         _log.warning("oauth_refresh_failed", detail="dropping stored refresh token")
-        payload = load_app_dir_config()
-        payload.pop("refresh_token", None)
-        CONFIG_FILE.write_text(json.dumps(payload))
-        load_app_dir_config.cache_clear()
-        get_settings.cache_clear()
+        _clear_refresh_token()
         return None
 
-    save_app_dir_config(token=tokens.access_token, refresh_token=tokens.refresh_token)
+    _persist_tokens(tokens.access_token, tokens.refresh_token)
     return tokens.access_token
 
 
@@ -57,6 +94,7 @@ class ProvablyHTTPClient:
     def __init__(self, settings: Settings | None = None, *, pre_auth: bool = False) -> None:
         self._client: httpx.AsyncClient | None = None
         self._client_loop: asyncio.AbstractEventLoop | None = None
+        self._post_auth = not pre_auth
 
         if pre_auth:
             self.base_url = get_bootstrap_settings()
@@ -65,7 +103,6 @@ class ProvablyHTTPClient:
             s = settings or get_settings()
             self.base_url = s.provably_api.rstrip("/")
             self._headers = {
-                "x-api-key": s.api_key,
                 "Content-Type": "application/json",
             }
 
@@ -123,6 +160,10 @@ class ProvablyHTTPClient:
         # Sentinel kwarg guards the single refresh-retry; never forwarded to httpx.
         kwargs.pop("_oauth_retried", None)
         _log.debug("provably_api_request", method=method, path=path)
+        # Post-auth requests authenticate with the OAuth access token unless an
+        # explicit credential is supplied
+        if token is None and api_key is None and self._post_auth:
+            token = get_settings().access_token
         try:
             response = await self._request(method, path, api_key=api_key, token=token, **kwargs)
             response.raise_for_status()
@@ -185,9 +226,20 @@ class ProvablyHTTPClient:
     ) -> bytes:
         """GET that returns raw response bytes instead of parsed JSON."""
         _log.debug("provably_api_request_raw", method="GET", path=path)
-        response = await self._request("GET", path, api_key=api_key, token=token)
-        response.raise_for_status()
-        return response.content
+        if token is None and api_key is None and self._post_auth:
+            token = get_settings().access_token
+        try:
+            response = await self._request("GET", path, api_key=api_key, token=token)
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401 and token is not None:
+                new_token = await _refresh_session()
+                if new_token is not None:
+                    response = await self._request("GET", path, api_key=api_key, token=new_token)
+                    response.raise_for_status()
+                    return response.content
+            raise
 
     async def post(
         self,
@@ -215,22 +267,20 @@ class ProvablyHTTPClient:
         data: dict[str, Any],
         *,
         files: dict[str, Any] | None = None,
-        api_key: str | None = None,
         token: str | None = None,
     ) -> Any:
         processed_payload = {key: (None, str(value)) for key, value in data.items()}
         if files:
             processed_payload.update(files)
-        return await self._fetch("POST", path, api_key=api_key, token=token, files=processed_payload)
+        return await self._fetch("POST", path, token=token, files=processed_payload)
 
     async def delete(
         self,
         path: str,
         *,
-        api_key: str | None = None,
         token: str | None = None,
     ) -> Any:
-        return await self._fetch("DELETE", path, api_key=api_key, token=token)
+        return await self._fetch("DELETE", path, token=token)
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/sourcerykit/provably/_http.py
+++ b/src/sourcerykit/provably/_http.py
@@ -27,13 +27,13 @@ async def _refresh_session() -> str | None:
     Returns None (and clears the stored refresh token) when no refresh token
     is configured or rotation fails.
     """
-    from sourcerykit.provably.oauth_login import refresh_tokens
+    from sourcerykit.provably.auth_service import auth_service
 
     refresh = load_app_dir_config().get("refresh_token")
     if not refresh:
         return None
     try:
-        tokens = await refresh_tokens(str(refresh))
+        tokens = await auth_service.refresh_tokens(str(refresh))
     except Exception:
         _log.warning("oauth_refresh_failed", detail="dropping stored refresh token")
         payload = load_app_dir_config()
@@ -95,7 +95,7 @@ class ProvablyHTTPClient:
 
         headers = {**self._headers}
 
-        if "files" in kwargs:
+        if "files" in kwargs or "data" in kwargs:
             headers.pop("Content-Type", None)
 
         if token is not None:
@@ -198,6 +198,16 @@ class ProvablyHTTPClient:
         token: str | None = None,
     ) -> Any:
         return await self._fetch("POST", path, api_key=api_key, token=token, json=json or {})
+
+    async def post_form(
+        self,
+        path: str,
+        data: dict[str, Any],
+        *,
+        token: str | None = None,
+    ) -> Any:
+        """POST with an ``application/x-www-form-urlencoded`` body."""
+        return await self._fetch("POST", path, token=token, data=data)
 
     async def post_multipart(
         self,

--- a/src/sourcerykit/provably/_http.py
+++ b/src/sourcerykit/provably/_http.py
@@ -2,15 +2,49 @@
 
 import asyncio
 import functools
+import json
 from typing import Any
 
 import httpx
 
-from sourcerykit.config import Settings, get_bootstrap_settings, get_settings
+from sourcerykit.config import (
+    CONFIG_FILE,
+    Settings,
+    get_bootstrap_settings,
+    get_settings,
+    load_app_dir_config,
+    save_app_dir_config,
+)
 from sourcerykit.intercept._self_egress import provably_self_egress
 from sourcerykit.logger import get_logger
 
 _log = get_logger(__name__)
+
+
+async def _refresh_session() -> str | None:
+    """Rotate the stored OAuth refresh token once; return the new access token.
+
+    Returns None (and clears the stored refresh token) when no refresh token
+    is configured or rotation fails.
+    """
+    from sourcerykit.provably.oauth_login import refresh_tokens
+
+    refresh = load_app_dir_config().get("refresh_token")
+    if not refresh:
+        return None
+    try:
+        tokens = await refresh_tokens(str(refresh))
+    except Exception:
+        _log.warning("oauth_refresh_failed", detail="dropping stored refresh token")
+        payload = load_app_dir_config()
+        payload.pop("refresh_token", None)
+        CONFIG_FILE.write_text(json.dumps(payload))
+        load_app_dir_config.cache_clear()
+        get_settings.cache_clear()
+        return None
+
+    save_app_dir_config(token=tokens.access_token, refresh_token=tokens.refresh_token)
+    return tokens.access_token
 
 
 class ProvablyHTTPClient:
@@ -77,8 +111,17 @@ class ProvablyHTTPClient:
             )
 
     async def _fetch(
-        self, method: str, path: str, *, api_key: str | None = None, token: str | None = None, **kwargs: Any
+        self,
+        method: str,
+        path: str,
+        *,
+        api_key: str | None = None,
+        token: str | None = None,
+        _oauth_retried: bool = False,
+        **kwargs: Any,
     ) -> Any:
+        # Sentinel kwarg guards the single refresh-retry; never forwarded to httpx.
+        kwargs.pop("_oauth_retried", None)
         _log.debug("provably_api_request", method=method, path=path)
         try:
             response = await self._request(method, path, api_key=api_key, token=token, **kwargs)
@@ -101,6 +144,13 @@ class ProvablyHTTPClient:
                 return {}
 
         except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401 and token is not None and not _oauth_retried:
+                new_token = await _refresh_session()
+                if new_token is not None:
+                    _log.info("provably_api_token_refreshed", method=method, path=path)
+                    return await self._fetch(
+                        method, path, api_key=api_key, token=new_token, _oauth_retried=True, **kwargs
+                    )
             _log.error(
                 "provably_api_rejected",
                 method=method,

--- a/src/sourcerykit/provably/auth_service.py
+++ b/src/sourcerykit/provably/auth_service.py
@@ -6,42 +6,12 @@ import uuid
 from typing import Any
 
 from sourcerykit.provably._api import get_api as get_main_api
-from sourcerykit.provably._auth_api import Organization, User, get_api
+from sourcerykit.provably._auth_api import Organization, get_api
 from sourcerykit.provably._errors import provably_auth_error_handler
 
 
 class ProvablyAuthService:
     """High-level service for account and organisation management."""
-
-    # ------------------------------------------------------------------
-    # Account
-    # ------------------------------------------------------------------
-
-    async def create_account(self, user: User) -> None:
-        """Register a new account.
-
-        Raises:
-            ProvablyResourceAlreadyExistsError: If an account with that email already exists.
-            ProvablyAuthError: For other 4xx/5xx responses.
-            ProvablyConnectionError: If the network is unreachable.
-        """
-        async with provably_auth_error_handler("create_account"):
-            await get_api().create_account(user)
-
-    async def login(self, user: User) -> dict[str, Any]:
-        """Authenticate with email and password.
-
-        Returns:
-            dict[str, Any]: The raw API response (contains ``token``).
-
-        Raises:
-            ProvablyUnauthorizedError: If credentials are wrong.
-            ProvablyAuthError: For other 4xx/5xx responses.
-            ProvablyConnectionError: If the network is unreachable.
-        """
-        async with provably_auth_error_handler("login"):
-            result = await get_api().login(user)
-            return result
 
     # ------------------------------------------------------------------
     # API Key

--- a/src/sourcerykit/provably/auth_service.py
+++ b/src/sourcerykit/provably/auth_service.py
@@ -6,12 +6,72 @@ import uuid
 from typing import Any
 
 from sourcerykit.provably._api import get_api as get_main_api
-from sourcerykit.provably._auth_api import Organization, get_api
+from sourcerykit.provably._auth_api import OAuthTokens, Organization, get_api
 from sourcerykit.provably._errors import provably_auth_error_handler
 
 
 class ProvablyAuthService:
     """High-level service for account and organisation management."""
+
+    # ------------------------------------------------------------------
+    # OAuth
+    # ------------------------------------------------------------------
+
+    async def exchange_code(self, code: str, verifier: str) -> OAuthTokens:
+        """Exchange an authorization code for tokens (public client, no secret).
+
+        Args:
+            code: The authorization code from the redirect.
+            verifier: The PKCE code verifier.
+
+        Returns:
+            OAuthTokens: The issued access and refresh tokens.
+
+        Raises:
+            ProvablyAuthError: On API errors.
+            ProvablyConnectionError: If the network is unreachable.
+        """
+        async with provably_auth_error_handler("oauth_token_exchange"):
+            result = await get_api().exchange_code(code, verifier)
+            return OAuthTokens(access_token=result["access_token"], refresh_token=result.get("refresh_token"))
+
+    async def refresh_tokens(self, refresh_token: str) -> OAuthTokens:
+        """Rotate tokens: exchange a refresh token for a new access+refresh pair.
+
+        Args:
+            refresh_token: The refresh token to redeem.
+
+        Returns:
+            OAuthTokens: The new access and refresh tokens.
+
+        Raises:
+            ProvablyAuthError: On API errors.
+            ProvablyConnectionError: If the network is unreachable.
+        """
+        async with provably_auth_error_handler("oauth_refresh"):
+            result = await get_api().refresh_tokens(refresh_token)
+            return OAuthTokens(access_token=result["access_token"], refresh_token=result.get("refresh_token"))
+
+    # ------------------------------------------------------------------
+    # User
+    # ------------------------------------------------------------------
+
+    async def get_user_email(self, token: str) -> str:
+        """Retrieve the email of the authenticated user.
+
+        Args:
+            token: OAuth access token (Bearer) from ``browser_login``.
+
+        Returns:
+            str: The user's email address.
+
+        Raises:
+            ProvablyAuthError: On API errors.
+            ProvablyConnectionError: If the network is unreachable.
+        """
+        async with provably_auth_error_handler("get_user_email"):
+            result = await get_api().get_current_user(token)
+            return str(result["email"])
 
     # ------------------------------------------------------------------
     # API Key

--- a/src/sourcerykit/provably/auth_service.py
+++ b/src/sourcerykit/provably/auth_service.py
@@ -74,27 +74,6 @@ class ProvablyAuthService:
             return str(result["email"])
 
     # ------------------------------------------------------------------
-    # API Key
-    # ------------------------------------------------------------------
-
-    async def get_api_key(self, token: str) -> str:
-        """Retrieve the API key for the authenticated user.
-
-        Args:
-            token: JWT Bearer token from ``login``.
-
-        Returns:
-            str: The API key string.
-
-        Raises:
-            ProvablyAuthError: On API errors.
-            ProvablyConnectionError: If the network is unreachable.
-        """
-        async with provably_auth_error_handler("get_api_key"):
-            result = await get_api().get_api_key(token)
-            return str(result["api_key"])
-
-    # ------------------------------------------------------------------
     # Organisation
     # ------------------------------------------------------------------
 

--- a/src/sourcerykit/provably/oauth_login.py
+++ b/src/sourcerykit/provably/oauth_login.py
@@ -1,8 +1,12 @@
 """OAuth2 login for the SourceryKit CLI — public client with PKCE (RFC 7636/8252).
 
-browser_login opens {provably_app}/consent?…, the web app drives
-sign-in and consent and redirects to this CLI's loopback listener.
-The client is public: no secret, PKCE S256 is the only proof.
+:func:`browser_login` opens ``{provably_app}/consent?…``; the web app drives
+sign-in and consent and redirects to this CLI's loopback listener
+(``http://127.0.0.1:8910/callback``). The client is public: no secret, PKCE
+S256 is the only proof.
+
+This module is pure OAuth orchestration — the token HTTP calls live in
+:mod:`sourcerykit.provably.auth_service`.
 """
 
 import asyncio
@@ -13,31 +17,20 @@ import secrets
 import threading
 import urllib.parse
 import webbrowser
-from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
 
-import httpx
-
-from sourcerykit.config import DEFAULT_PROVABLY_APP_URL, get_bootstrap_settings, load_app_dir_config
-from sourcerykit.intercept._self_egress import provably_self_egress
+from sourcerykit.config import DEFAULT_PROVABLY_APP_URL, load_app_dir_config
 from sourcerykit.logger import get_logger
-from sourcerykit.provably._errors import provably_auth_error_handler
+from sourcerykit.provably._auth_api import (
+    LOOPBACK_PORT,
+    OAUTH_CLIENT_ID,
+    OAUTH_SCOPE,
+    REDIRECT_URI,
+    OAuthTokens,
+)
+from sourcerykit.provably.auth_service import auth_service
 
 _log = get_logger(__name__)
-
-OAUTH_CLIENT_ID = "sourcerykit-cli"
-OAUTH_SCOPE = "read write"
-LOOPBACK_PORT = 8910
-REDIRECT_URI = f"http://127.0.0.1:{LOOPBACK_PORT}/callback"
-
-
-@dataclass(slots=True)
-class OAuthTokens:
-    """Tokens issued by the OAuth token endpoint."""
-
-    access_token: str
-    refresh_token: str | None
 
 
 def pkce_pair() -> tuple[str, str]:
@@ -46,10 +39,6 @@ def pkce_pair() -> tuple[str, str]:
     digest = hashlib.sha256(verifier.encode()).digest()
     challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
     return verifier, challenge
-
-
-def _base_url() -> str:
-    return get_bootstrap_settings().rstrip("/")
 
 
 def consent_page_url() -> str:
@@ -64,78 +53,6 @@ def consent_page_url() -> str:
         raw = str(load_app_dir_config().get("provably_app", ""))
     raw = raw.strip().rstrip("/")
     return raw or f"{DEFAULT_PROVABLY_APP_URL}/consent"
-
-
-async def _request(client: httpx.AsyncClient, method: str, url: str, **kwargs: Any) -> httpx.Response:
-    """httpx call marked as SDK-internal egress so it bypasses intercept hooks."""
-    with provably_self_egress():
-        return await client.request(method, url, timeout=30.0, **kwargs)
-
-
-async def _exchange_code(client: httpx.AsyncClient, code: str, verifier: str) -> OAuthTokens:
-    """Exchange an authorization code for tokens (public client, no secret)."""
-    async with provably_auth_error_handler("oauth_token_exchange"):
-        res = await _request(
-            client,
-            "POST",
-            f"{_base_url()}/api/v1/auth/oauth/token",
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": REDIRECT_URI,
-                "client_id": OAUTH_CLIENT_ID,
-                "code_verifier": verifier,
-            },
-        )
-        res.raise_for_status()
-        body = res.json()
-        return OAuthTokens(access_token=body["access_token"], refresh_token=body.get("refresh_token"))
-
-
-async def refresh_tokens(refresh_token: str) -> OAuthTokens:
-    """Rotate tokens: exchange a refresh token for a new access+refresh pair."""
-    async with provably_auth_error_handler("oauth_refresh"):
-        async with httpx.AsyncClient() as client:
-            res = await _request(
-                client,
-                "POST",
-                f"{_base_url()}/api/v1/auth/oauth/refresh",
-                data={
-                    "grant_type": "refresh_token",
-                    "refresh_token": refresh_token,
-                    "client_id": OAUTH_CLIENT_ID,
-                },
-            )
-            res.raise_for_status()
-            body = res.json()
-            return OAuthTokens(access_token=body["access_token"], refresh_token=body.get("refresh_token"))
-
-
-async def fetch_user_email(access_token: str) -> str:
-    """Return the authenticated user's email from the ``/user/current`` endpoint.
-
-    Args:
-        access_token: The OAuth access token (Bearer).
-
-    Returns:
-        str: The user's email (top-level ``email`` field).
-
-    Raises:
-        ValueError: If the response has no email.
-    """
-    async with provably_auth_error_handler("oauth_userinfo"):
-        async with httpx.AsyncClient() as client:
-            res = await _request(
-                client,
-                "GET",
-                f"{_base_url()}/api/v1/user/current",
-                headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
-            )
-            res.raise_for_status()
-            email = res.json().get("email", "")
-    if not email:
-        raise ValueError("/api/v1/user/current response did not contain an email")
-    return str(email)
 
 
 # ----------------------------------------------------------------------
@@ -200,8 +117,7 @@ async def browser_login(consent_page: str | None = None) -> OAuthTokens:
         }
     )
 
-    print("Opening browser for authentication...")
-    print(f"  {consent_url}")
+    _log.info("oauth_browser_opening", consent_url=consent_url)
     webbrowser.open(consent_url)
 
     callback = await _wait_for_loopback_code()
@@ -212,5 +128,4 @@ async def browser_login(consent_page: str | None = None) -> OAuthTokens:
         error = callback.get("error", "unknown error")
         raise ValueError(f"authorization denied: {error}")
 
-    async with httpx.AsyncClient() as client:
-        return await _exchange_code(client, code, verifier)
+    return await auth_service.exchange_code(code, verifier)

--- a/src/sourcerykit/provably/oauth_login.py
+++ b/src/sourcerykit/provably/oauth_login.py
@@ -1,0 +1,216 @@
+"""OAuth2 login for the SourceryKit CLI — public client with PKCE (RFC 7636/8252).
+
+browser_login opens {provably_app}/consent?…, the web app drives
+sign-in and consent and redirects to this CLI's loopback listener.
+The client is public: no secret, PKCE S256 is the only proof.
+"""
+
+import asyncio
+import base64
+import hashlib
+import os
+import secrets
+import threading
+import urllib.parse
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import httpx
+
+from sourcerykit.config import DEFAULT_PROVABLY_APP_URL, get_bootstrap_settings, load_app_dir_config
+from sourcerykit.intercept._self_egress import provably_self_egress
+from sourcerykit.logger import get_logger
+from sourcerykit.provably._errors import provably_auth_error_handler
+
+_log = get_logger(__name__)
+
+OAUTH_CLIENT_ID = "sourcerykit-cli"
+OAUTH_SCOPE = "read write"
+LOOPBACK_PORT = 8910
+REDIRECT_URI = f"http://127.0.0.1:{LOOPBACK_PORT}/callback"
+
+
+@dataclass(slots=True)
+class OAuthTokens:
+    """Tokens issued by the OAuth token endpoint."""
+
+    access_token: str
+    refresh_token: str | None
+
+
+def pkce_pair() -> tuple[str, str]:
+    """Return ``(verifier, challenge)`` using the S256 method."""
+    verifier = secrets.token_urlsafe(48)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _base_url() -> str:
+    return get_bootstrap_settings().rstrip("/")
+
+
+def consent_page_url() -> str:
+    """URL of the web app consent page.
+
+    When ``SOURCERYKIT_PROVABLY_APP_URL`` (or ``provably_app``) is set it is
+    used verbatim as the consent page URL — point it at your app's consent page
+    in dev. When unset, falls back to the production app's ``/consent`` page.
+    """
+    raw = os.environ.get("SOURCERYKIT_PROVABLY_APP_URL") or ""
+    if not raw:
+        raw = str(load_app_dir_config().get("provably_app", ""))
+    raw = raw.strip().rstrip("/")
+    return raw or f"{DEFAULT_PROVABLY_APP_URL}/consent"
+
+
+async def _request(client: httpx.AsyncClient, method: str, url: str, **kwargs: Any) -> httpx.Response:
+    """httpx call marked as SDK-internal egress so it bypasses intercept hooks."""
+    with provably_self_egress():
+        return await client.request(method, url, timeout=30.0, **kwargs)
+
+
+async def _exchange_code(client: httpx.AsyncClient, code: str, verifier: str) -> OAuthTokens:
+    """Exchange an authorization code for tokens (public client, no secret)."""
+    async with provably_auth_error_handler("oauth_token_exchange"):
+        res = await _request(
+            client,
+            "POST",
+            f"{_base_url()}/api/v1/auth/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+                "client_id": OAUTH_CLIENT_ID,
+                "code_verifier": verifier,
+            },
+        )
+        res.raise_for_status()
+        body = res.json()
+        return OAuthTokens(access_token=body["access_token"], refresh_token=body.get("refresh_token"))
+
+
+async def refresh_tokens(refresh_token: str) -> OAuthTokens:
+    """Rotate tokens: exchange a refresh token for a new access+refresh pair."""
+    async with provably_auth_error_handler("oauth_refresh"):
+        async with httpx.AsyncClient() as client:
+            res = await _request(
+                client,
+                "POST",
+                f"{_base_url()}/api/v1/auth/oauth/refresh",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": OAUTH_CLIENT_ID,
+                },
+            )
+            res.raise_for_status()
+            body = res.json()
+            return OAuthTokens(access_token=body["access_token"], refresh_token=body.get("refresh_token"))
+
+
+async def fetch_user_email(access_token: str) -> str:
+    """Return the authenticated user's email from the ``/user/current`` endpoint.
+
+    Args:
+        access_token: The OAuth access token (Bearer).
+
+    Returns:
+        str: The user's email (top-level ``email`` field).
+
+    Raises:
+        ValueError: If the response has no email.
+    """
+    async with provably_auth_error_handler("oauth_userinfo"):
+        async with httpx.AsyncClient() as client:
+            res = await _request(
+                client,
+                "GET",
+                f"{_base_url()}/api/v1/user/current",
+                headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
+            )
+            res.raise_for_status()
+            email = res.json().get("email", "")
+    if not email:
+        raise ValueError("/api/v1/user/current response did not contain an email")
+    return str(email)
+
+
+# ----------------------------------------------------------------------
+# Browser flow
+# ----------------------------------------------------------------------
+
+
+class _LoopbackCallbackHandler(BaseHTTPRequestHandler):
+    """Captures ?code/&state on GET /callback and signals completion."""
+
+    result: dict[str, str] = {}
+    done = threading.Event()
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib API
+        parsed = urllib.parse.parse_qsl(urllib.parse.urlsplit(self.path).query)
+        type(self).result = dict(parsed)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(b"<html><body><h2>Logged in!</h2>You can close this window.</body></html>")
+        type(self).done.set()
+
+    def log_message(self, format: str, *args: object) -> None:  # silence stderr
+        pass
+
+
+async def _wait_for_loopback_code(timeout: float = 300.0) -> dict[str, str]:
+    """Bind the registered loopback port and wait for the OAuth redirect."""
+    server = HTTPServer(("127.0.0.1", LOOPBACK_PORT), _LoopbackCallbackHandler)
+    _LoopbackCallbackHandler.result = {}
+    _LoopbackCallbackHandler.done.clear()
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.2}, daemon=True)
+    thread.start()
+    try:
+        await asyncio.wait_for(asyncio.to_thread(_LoopbackCallbackHandler.done.wait), timeout)
+    finally:
+        server.shutdown()
+        server.server_close()
+    return _LoopbackCallbackHandler.result
+
+
+async def browser_login(consent_page: str | None = None) -> OAuthTokens:
+    """Open the web app's consent page and complete the loopback redirect flow.
+
+    Args:
+        consent_page: Full URL of the consent page. Defaults to
+            :func:`consent_page_url`.
+    """
+    verifier, challenge = pkce_pair()
+    state = secrets.token_urlsafe(16)
+
+    page = (consent_page or consent_page_url()).split("?", 1)[0]
+    consent_url = f"{page}?" + urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": OAUTH_CLIENT_ID,
+            "redirect_uri": REDIRECT_URI,
+            "scope": OAUTH_SCOPE,
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+
+    print("Opening browser for authentication...")
+    print(f"  {consent_url}")
+    webbrowser.open(consent_url)
+
+    callback = await _wait_for_loopback_code()
+    if callback.get("state") != state:
+        raise ValueError("OAuth state mismatch — aborting")
+    code = callback.get("code", "")
+    if not code:
+        error = callback.get("error", "unknown error")
+        raise ValueError(f"authorization denied: {error}")
+
+    async with httpx.AsyncClient() as client:
+        return await _exchange_code(client, code, verifier)

--- a/src/sourcerykit/provably/service.py
+++ b/src/sourcerykit/provably/service.py
@@ -393,14 +393,17 @@ class ProvablyService:
     # Integrations
     # ------------------------------------------------------------------
 
-    async def create_integration(self, collection_id: uuid.UUID) -> tuple[uuid.UUID, str]:
-        """Register a new agent integration for the intercepts collection.
+    async def ensure_integration(self, collection_id: uuid.UUID) -> tuple[uuid.UUID, str]:
+        """Idempotent get-or-create of the intercepts integration for a collection.
+
+        Reuses an existing enabled integration for the collection (returning its
+        current key) instead of minting a duplicate on every bootstrap.
 
         Args:
             collection_id: The ID of the collection to associate with the integration.
 
         Returns:
-            tuple[uuid.UUID, str]: The ID and full API key of the newly created integration.
+            tuple[uuid.UUID, str]: The ID and full API key of the integration.
 
         Raises:
             ProvablyAPIError: If the server rejects the request.
@@ -416,72 +419,12 @@ class ProvablyService:
             "collections": [str(collection_id)],
         }
 
-        async with provably_error_handler("create_integration"):
-            result = await get_api().create_integration(integration)
+        async with provably_error_handler("ensure_integration"):
+            result = await get_api().ensure_integration(integration)
             api_key = result.get("api_key")
             if not api_key:
-                raise ValueError("create_integration response missing 'api_key'")
+                raise ValueError("ensure_integration response missing 'api_key'")
             return uuid.UUID(str(result["id"])), str(api_key)
-
-    async def get_integration_intercepts_api_key(self, collection_id: uuid.UUID) -> str:
-        """Find the intercepts integration, verify collection access, and return its API key.
-
-        Args:
-            collection_id: The collection ID the integration must have access to.
-
-        Returns:
-            str: The API key for the intercepts integration.
-
-        Raises:
-            ValueError: If the integration is not found, does not have access to the
-                collection, or the API key is missing.
-            ProvablyAPIError: If the server rejects the request.
-            ProvablyConnectionError: If the network is unreachable.
-        """
-        async with provably_error_handler("get_integration_intercepts_id"):
-            integrations = await get_api().list_integrations(query=INTERCEPTS_TABLE)
-
-            candidates = [i for i in integrations if i.get("name") == INTERCEPTS_TABLE]
-            if not candidates:
-                raise ValueError(f"No integration named '{INTERCEPTS_TABLE}' was found.")
-
-            # collections and api_key are only present in get_integration_by_id
-            full_records = await asyncio.gather(
-                *(get_api().get_integration_by_id(uuid.UUID(str(c["id"]))) for c in candidates)
-            )
-
-            match = next(
-                (r for r in full_records if str(collection_id) in [str(c) for c in r.get("collections", [])]),
-                None,
-            )
-            if match is None:
-                raise ValueError(
-                    f"No integration named '{INTERCEPTS_TABLE}' with access to collection {collection_id} was found."
-                )
-
-            print("MATCH: ", match)
-
-            api_key = match.get("api_key")
-            if not api_key:
-                raise ValueError(f"Integration '{INTERCEPTS_TABLE}' found, but 'api_key' is missing.")
-
-            return str(api_key)
-
-    async def get_integration_by_id(self, integration_id: uuid.UUID) -> dict[str, Any]:
-        """Return the full integration record by ID.
-
-        Args:
-            integration_id: The ID of the integration to look up.
-
-        Returns:
-            dict[str, Any]: The raw integration record from the API.
-
-        Raises:
-            ProvablyAPIError: If the server rejects the request.
-            ProvablyConnectionError: If the network is unreachable.
-        """
-        async with provably_error_handler("get_integration_by_id"):
-            return await get_api().get_integration_by_id(integration_id)
 
     # ------------------------------------------------------------------
     # Preprocess

--- a/tests/e2e/test_evaluate_handoff_e2e.py
+++ b/tests/e2e/test_evaluate_handoff_e2e.py
@@ -73,7 +73,7 @@ def _failed_proof_response() -> dict[str, Any]:
 def _provably_settings(fake_server: FakeHttpServer) -> Settings:
     """Settings object whose provably_api URL points at the loopback fake server."""
     return Settings(
-        api_key="int-test-key",
+        access_token="int-test-token",
         org_id=_ORG,
         postgres_url="postgresql://test/db",
         provably_api=fake_server.base_url,
@@ -93,17 +93,13 @@ def _wired_service(_provably_settings: Settings, monkeypatch: pytest.MonkeyPatch
     We patch:
       - ``sourcerykit.provably._api.get_http`` to return our ProvablyHTTPClient
       - ``sourcerykit.provably.service.get_api`` to return our ProvablyAPI
-      - ``sourcerykit.evaluator.evaluator.get_settings`` to return fake_settings
+      - ``sourcerykit.evaluator.evaluator.update_trace``
     """
     http_client = ProvablyHTTPClient(settings=_provably_settings)
     api = ProvablyAPI(settings=_provably_settings)
 
     monkeypatch.setattr("sourcerykit.provably._api.get_http", lambda: http_client)
     monkeypatch.setattr("sourcerykit.provably.service.get_api", lambda: api)
-    monkeypatch.setattr(
-        "sourcerykit.evaluator.evaluator.get_settings",
-        lambda: _provably_settings,
-    )
     monkeypatch.setattr(
         "sourcerykit.evaluator.evaluator.update_trace",
         AsyncMock(),
@@ -281,7 +277,7 @@ class TestEvaluateHandoffE2E:
         _wired_service: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The x-api-key header on proof verification must come from get_settings().api_key."""
+        """The x-api-key header on proof verification must be the payload's integration key."""
         qid = uuid.uuid4()
         fake_server.respond("POST", f"{_ORG_PATH}/queries/{qid}/verify", status=200, body={})
         fake_server.respond("GET", f"{_ORG_PATH}/queries/{qid}", status=200, body=_verified_response("open"))

--- a/tests/unit/test_auth_api.py
+++ b/tests/unit/test_auth_api.py
@@ -4,6 +4,8 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sourcerykit.provably._auth_api import (
+    OAUTH_CLIENT_ID,
+    REDIRECT_URI,
     Organization,
     OrganizationType,
     ProvablyAuthAPI,
@@ -21,6 +23,53 @@ def _make_api() -> tuple[ProvablyAuthAPI, MagicMock]:
     mock_http = MagicMock()
     api._http = mock_http
     return api, mock_http
+
+
+class TestProvablyAuthAPIOAuth:
+    async def test_exchange_code_posts_form(self) -> None:
+        api, mock_http = _make_api()
+        mock_http.post_form = AsyncMock(return_value={"access_token": "at", "refresh_token": "rt"})
+
+        result = await api.exchange_code("CODE", "VERIFIER")
+
+        mock_http.post_form.assert_called_once_with(
+            "/api/v1/auth/oauth/token",
+            {
+                "grant_type": "authorization_code",
+                "code": "CODE",
+                "redirect_uri": REDIRECT_URI,
+                "client_id": OAUTH_CLIENT_ID,
+                "code_verifier": "VERIFIER",
+            },
+        )
+        assert result == {"access_token": "at", "refresh_token": "rt"}
+
+    async def test_refresh_tokens_posts_form(self) -> None:
+        api, mock_http = _make_api()
+        mock_http.post_form = AsyncMock(return_value={"access_token": "new-at", "refresh_token": "new-rt"})
+
+        result = await api.refresh_tokens("old-rt")
+
+        mock_http.post_form.assert_called_once_with(
+            "/api/v1/auth/oauth/refresh",
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": "old-rt",
+                "client_id": OAUTH_CLIENT_ID,
+            },
+        )
+        assert result == {"access_token": "new-at", "refresh_token": "new-rt"}
+
+
+class TestProvablyAuthAPIUser:
+    async def test_get_current_user_calls_get_with_token(self) -> None:
+        api, mock_http = _make_api()
+        mock_http.get = AsyncMock(return_value={"email": "user@example.com"})
+
+        result = await api.get_current_user(_TOKEN)
+
+        mock_http.get.assert_called_once_with("/api/v1/user/current", token=_TOKEN)
+        assert result == {"email": "user@example.com"}
 
 
 class TestProvablyAuthAPIApiKey:

--- a/tests/unit/test_auth_api.py
+++ b/tests/unit/test_auth_api.py
@@ -72,17 +72,6 @@ class TestProvablyAuthAPIUser:
         assert result == {"email": "user@example.com"}
 
 
-class TestProvablyAuthAPIApiKey:
-    async def test_get_api_key_calls_get_with_token(self) -> None:
-        api, mock_http = _make_api()
-        mock_http.get = AsyncMock(return_value={"api_key": "key-xyz"})
-
-        result = await api.get_api_key(_TOKEN)
-
-        mock_http.get.assert_called_once_with("/api/v1/user/key", token=_TOKEN)
-        assert result == {"api_key": "key-xyz"}
-
-
 class TestProvablyAuthAPIOrganization:
     async def test_create_organization_calls_post_multipart_with_token(self) -> None:
         org_id = str(uuid.uuid4())

--- a/tests/unit/test_auth_api.py
+++ b/tests/unit/test_auth_api.py
@@ -1,18 +1,15 @@
 """Tests for sourcerykit.provably._auth_api.ProvablyAuthAPI."""
 
 import uuid
-from dataclasses import asdict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sourcerykit.provably._auth_api import (
     Organization,
     OrganizationType,
     ProvablyAuthAPI,
-    User,
 )
 
 _TOKEN = "test-jwt-token"
-_USER = User(email="user@example.com", password="secret")
 _ORG = Organization(handle="my-org", name="My Org", organization_type=OrganizationType.EDUCATION)
 
 
@@ -24,31 +21,6 @@ def _make_api() -> tuple[ProvablyAuthAPI, MagicMock]:
     mock_http = MagicMock()
     api._http = mock_http
     return api, mock_http
-
-
-class TestProvablyAuthAPIAccount:
-    async def test_create_account_calls_post_register(self) -> None:
-        api, mock_http = _make_api()
-        mock_http.post = AsyncMock(return_value={})
-
-        await api.create_account(_USER)
-
-        mock_http.post.assert_called_once_with(
-            "/api/v1/auth/register",
-            asdict(_USER),
-        )
-
-    async def test_login_calls_post_login_and_returns_dict(self) -> None:
-        api, mock_http = _make_api()
-        mock_http.post = AsyncMock(return_value={"token": "abc123"})
-
-        result = await api.login(_USER)
-
-        mock_http.post.assert_called_once_with(
-            "/api/v1/auth/login",
-            asdict(_USER),
-        )
-        assert result == {"token": "abc123"}
 
 
 class TestProvablyAuthAPIApiKey:

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from sourcerykit.provably._auth_api import Organization, OrganizationType, User
+from sourcerykit.provably._auth_api import Organization, OrganizationType
 from sourcerykit.provably._errors import (
     ProvablyConnectionError,
     ProvablyResourceAlreadyExistsError,
@@ -15,7 +15,6 @@ from sourcerykit.provably._errors import (
 from sourcerykit.provably.auth_service import ProvablyAuthService
 
 _TOKEN = "test-jwt-token"
-_USER = User(email="user@example.com", password="secret")
 _ORG = Organization(handle="my-org", name="My Org", organization_type=OrganizationType.EDUCATION)
 _ORG_ID = uuid.uuid4()
 
@@ -25,56 +24,6 @@ def _make_service() -> tuple[ProvablyAuthService, MagicMock]:
     service = ProvablyAuthService()
     mock_api = MagicMock()
     return service, mock_api
-
-
-class TestProvablyAuthServiceAccount:
-    async def test_create_account_happy_path(self) -> None:
-        service, mock_api = _make_service()
-        mock_api.create_account = AsyncMock(return_value=None)
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            await service.create_account(_USER)
-
-        mock_api.create_account.assert_called_once_with(_USER)
-
-    async def test_create_account_connection_error(self) -> None:
-        service, mock_api = _make_service()
-        req = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/register")
-        mock_api.create_account = AsyncMock(side_effect=httpx.ConnectError("refused", request=req))
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            with pytest.raises(ProvablyConnectionError):
-                await service.create_account(_USER)
-
-    async def test_login_happy_path(self) -> None:
-        service, mock_api = _make_service()
-        mock_api.login = AsyncMock(return_value={"token": "abc123"})
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            result = await service.login(_USER)
-
-        assert result == {"token": "abc123"}
-
-    async def test_login_unauthorized_raises_error(self) -> None:
-        service, mock_api = _make_service()
-        mock_request = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/login")
-        mock_response = httpx.Response(401, request=mock_request, text="Unauthorized")
-        mock_api.login = AsyncMock(
-            side_effect=httpx.HTTPStatusError("401", request=mock_request, response=mock_response)
-        )
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            with pytest.raises(ProvablyUnauthorizedError):
-                await service.login(_USER)
-
-    async def test_login_connection_error(self) -> None:
-        service, mock_api = _make_service()
-        req = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/login")
-        mock_api.login = AsyncMock(side_effect=httpx.ConnectError("refused", request=req))
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            with pytest.raises(ProvablyConnectionError):
-                await service.login(_USER)
 
 
 class TestProvablyAuthServiceApiKey:

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from sourcerykit.provably._auth_api import Organization, OrganizationType
+from sourcerykit.provably._auth_api import OAuthTokens, Organization, OrganizationType
 from sourcerykit.provably._errors import (
     ProvablyConnectionError,
     ProvablyResourceAlreadyExistsError,
@@ -24,6 +24,50 @@ def _make_service() -> tuple[ProvablyAuthService, MagicMock]:
     service = ProvablyAuthService()
     mock_api = MagicMock()
     return service, mock_api
+
+
+class TestProvablyAuthServiceOAuth:
+    async def test_exchange_code_returns_tokens(self) -> None:
+        service, mock_api = _make_service()
+        mock_api.exchange_code = AsyncMock(return_value={"access_token": "at", "refresh_token": "rt"})
+
+        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
+            result = await service.exchange_code("CODE", "VERIFIER")
+
+        assert isinstance(result, OAuthTokens)
+        assert result.access_token == "at"
+        assert result.refresh_token == "rt"
+
+    async def test_refresh_tokens_rotates(self) -> None:
+        service, mock_api = _make_service()
+        mock_api.refresh_tokens = AsyncMock(return_value={"access_token": "new-at", "refresh_token": "new-rt"})
+
+        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
+            result = await service.refresh_tokens("old-rt")
+
+        assert result.access_token == "new-at"
+        assert result.refresh_token == "new-rt"
+
+
+class TestProvablyAuthServiceUserEmail:
+    async def test_returns_email(self) -> None:
+        service, mock_api = _make_service()
+        mock_api.get_current_user = AsyncMock(return_value={"email": "user@example.com"})
+
+        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
+            result = await service.get_user_email(_TOKEN)
+
+        assert result == "user@example.com"
+
+    async def test_missing_email_raises_data_error(self) -> None:
+        from sourcerykit.provably._errors import ProvablyDataError
+
+        service, mock_api = _make_service()
+        mock_api.get_current_user = AsyncMock(return_value={})
+
+        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
+            with pytest.raises(ProvablyDataError):
+                await service.get_user_email(_TOKEN)
 
 
 class TestProvablyAuthServiceApiKey:

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -70,27 +70,6 @@ class TestProvablyAuthServiceUserEmail:
                 await service.get_user_email(_TOKEN)
 
 
-class TestProvablyAuthServiceApiKey:
-    async def test_get_api_key_returns_string(self) -> None:
-        service, mock_api = _make_service()
-        mock_api.get_api_key = AsyncMock(return_value={"api_key": "my-key-abc"})
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            result = await service.get_api_key(_TOKEN)
-
-        assert result == "my-key-abc"
-
-    async def test_get_api_key_missing_key_raises_data_error(self) -> None:
-        from sourcerykit.provably._errors import ProvablyDataError
-
-        service, mock_api = _make_service()
-        mock_api.get_api_key = AsyncMock(return_value={})
-
-        with patch("sourcerykit.provably.auth_service.get_api", return_value=mock_api):
-            with pytest.raises(ProvablyDataError):
-                await service.get_api_key(_TOKEN)
-
-
 class TestProvablyAuthServiceOrganization:
     async def test_create_organization_returns_uuid(self) -> None:
         service, mock_api = _make_service()

--- a/tests/unit/test_call_ref.py
+++ b/tests/unit/test_call_ref.py
@@ -25,7 +25,7 @@ def _env(monkeypatch: pytest.MonkeyPatch) -> None:
     get_settings.cache_clear()
     load_app_dir_config.cache_clear()
     load_local_env.cache_clear()
-    monkeypatch.setenv("PROVABLY_API_KEY", "k")
+    monkeypatch.setenv("PROVABLY_ACCESS_TOKEN", "k")
     monkeypatch.setenv("SOURCERYKIT_ORG_ID", str(uuid.uuid4()))
     monkeypatch.setenv("SOURCERYKIT_POSTGRES_URL", "postgresql://x")
     monkeypatch.setenv("SOURCERYKIT_PROVABLY_MCP_URL", "https://mcp.example.com")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,8 +6,7 @@ import pytest
 import typer
 
 from sourcerykit.cli.init import (
-    _run_login,
-    _run_register,
+    _run_oauth_browser,
 )
 from sourcerykit.cli.utils import (
     _normalize_postgres_url,
@@ -18,7 +17,8 @@ from sourcerykit.cli.utils import (
     require_settings,
     run_connectivity_check,
 )
-from sourcerykit.provably._errors import ProvablyConnectionError, ProvablyUnauthorizedError
+from sourcerykit.provably._errors import ProvablyConnectionError
+from sourcerykit.provably.oauth_login import OAuthTokens
 
 _VALID_POSTGRES_URL = "postgresql://user:pass@1.2.3.4:5432/mydb"
 
@@ -103,184 +103,45 @@ class TestRunConnectivityCheck:
 
 
 # ---------------------------------------------------------------------------
-# _run_register
+# _run_oauth_browser
 # ---------------------------------------------------------------------------
 
 
-class TestRunRegister:
-    def test_returns_email_on_successful_registration(self) -> None:
+class TestRunOauthBrowser:
+    def test_logs_in_and_runs_post_auth_with_flags(self) -> None:
+        tokens = OAuthTokens(access_token="at", refresh_token="rt")
         with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-        ):
-            mock_q.prompt.return_value = {"email": "new@example.com", "password": "pw"}
-            mock_q.press_any_key_to_continue.return_value.ask = MagicMock(return_value=None)
-            mock_service.create_account = AsyncMock(return_value=None)
-
-            result = _run_register()
-
-        assert result == "new@example.com"
-
-    def test_returns_empty_string_on_connection_error(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-        ):
-            mock_q.prompt.return_value = {"email": "new@example.com", "password": "pw"}
-            mock_service.create_account = AsyncMock(side_effect=ProvablyConnectionError("Network unreachable"))
-
-            result = _run_register()
-
-        assert result == ""
-
-    def test_returns_empty_string_when_inputs_cancelled(self) -> None:
-        with patch("sourcerykit.cli.init.questionary") as mock_q:
-            mock_q.prompt.return_value = None
-
-            result = _run_register()
-
-        assert result == ""
-
-
-# ---------------------------------------------------------------------------
-# _run_register (non-interactive)
-# ---------------------------------------------------------------------------
-
-
-class TestRunRegisterNonInteractive:
-    def test_creates_account_and_exits(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
+            patch("sourcerykit.cli.init.browser_login", new=AsyncMock(return_value=tokens)),
+            patch("sourcerykit.cli.init.fetch_user_email", new=AsyncMock(return_value="user@example.com")),
+            patch("sourcerykit.cli.init.save_app_dir_config") as mock_save,
+            patch("sourcerykit.cli.init._execute_post_auth_phases", return_value=True) as mock_phases,
             patch("sourcerykit.cli.init.console"),
         ):
-            mock_service.create_account = AsyncMock(return_value=None)
-
             with pytest.raises(typer.Exit):
-                _run_register(email="new@example.com", password="pw")
+                _run_oauth_browser(
+                    postgres_url="postgresql://u:p@h:5432/db",
+                    project_name="proj",
+                    sandbox=True,
+                )
 
-        mock_service.create_account.assert_called_once()
-        mock_q.prompt.assert_not_called()
-        mock_q.press_any_key_to_continue.assert_not_called()
-
-    def test_handles_already_registered_error(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary"),
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_service.create_account = AsyncMock(side_effect=ProvablyUnauthorizedError("Already registered"))
-
-            result = _run_register(email="new@example.com", password="pw")
-
-        assert result == ""
-
-    def test_handles_connection_error(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary"),
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_service.create_account = AsyncMock(side_effect=ProvablyConnectionError("Unreachable"))
-
-            result = _run_register(email="new@example.com", password="pw")
-
-        assert result == ""
-
-
-# ---------------------------------------------------------------------------
-# _run_login
-# ---------------------------------------------------------------------------
-
-
-class TestRunLogin:
-    def test_calls_execute_post_auth_phases_on_success(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_q.text.return_value.ask.return_value = "user@example.com"
-            mock_q.password.return_value.ask.return_value = "secret"
-            mock_service.login = AsyncMock(return_value={"token": "jwt-abc"})
-            mock_phases.return_value = True
-
-            with pytest.raises(typer.Exit):
-                _run_login()
-
+        mock_save.assert_called_once_with(token="at", refresh_token="rt", email="user@example.com")
         mock_phases.assert_called_once_with(
-            "jwt-abc",
+            "at",
             email="user@example.com",
-            postgres_url=None,
-            project_name=None,
-            sandbox=False,
+            postgres_url="postgresql://u:p@h:5432/db",
+            project_name="proj",
+            sandbox=True,
         )
 
-    def test_handles_unauthorized_error_without_crash(self) -> None:
+    def test_returns_without_phases_on_connection_error(self) -> None:
         with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
+            patch("sourcerykit.cli.init.browser_login", new=AsyncMock(side_effect=ProvablyConnectionError("down"))),
             patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
             patch("sourcerykit.cli.init.console"),
         ):
-            mock_q.text.return_value.ask.return_value = "user@example.com"
-            mock_q.password.return_value.ask.return_value = "wrong"
-            mock_service.login = AsyncMock(side_effect=ProvablyUnauthorizedError("Bad creds"))
-
-            _run_login()  # must not raise
+            _run_oauth_browser(sandbox=True)  # must not raise
 
         mock_phases.assert_not_called()
-
-    def test_handles_connection_error_without_crash(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_q.text.return_value.ask.return_value = "user@example.com"
-            mock_q.password.return_value.ask.return_value = "pass"
-            mock_service.login = AsyncMock(side_effect=ProvablyConnectionError("Unreachable"))
-
-            _run_login()  # must not raise
-
-        mock_phases.assert_not_called()
-
-    def test_returns_early_when_token_missing_from_response(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_q.text.return_value.ask.return_value = "user@example.com"
-            mock_q.password.return_value.ask.return_value = "pass"
-            mock_service.login = AsyncMock(return_value={})  # no token key
-
-            _run_login()
-
-        mock_phases.assert_not_called()
-
-    def test_prefill_email_passed_to_text_prompt(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases"),
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_q.text.return_value.ask.return_value = None  # user cancels
-            mock_service.login = AsyncMock(return_value={"token": "t"})
-
-            _run_login(prefill_email="pre@example.com")
-
-            _, kwargs = mock_q.text.call_args
-            assert kwargs.get("default") == "pre@example.com"
-
-
-# ---------------------------------------------------------------------------
-# mask_secret
-# ---------------------------------------------------------------------------
 
 
 class TestMaskSecret:
@@ -414,79 +275,3 @@ class TestNormalizePostgresUrl:
         url = "postgresql://host:5432/mydb"
         result = _normalize_postgres_url(url)
         assert result == url
-
-
-# ---------------------------------------------------------------------------
-# _run_login (non-interactive)
-# ---------------------------------------------------------------------------
-
-
-class TestRunLoginNonInteractive:
-    def test_skips_prompts_when_email_and_password_provided(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary") as mock_q,
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_service.login = AsyncMock(return_value={"token": "jwt-abc"})
-            mock_phases.return_value = True
-
-            with pytest.raises(typer.Exit):
-                _run_login(email="a@b.com", password="pw")
-
-        mock_q.text.assert_not_called()
-        mock_q.password.assert_not_called()
-        mock_service.login.assert_called_once()
-
-    def test_passes_flags_to_post_auth_phases(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary"),
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_service.login = AsyncMock(return_value={"token": "jwt-abc"})
-            mock_phases.return_value = True
-
-            with pytest.raises(typer.Exit):
-                _run_login(
-                    email="a@b.com",
-                    password="pw",
-                    postgres_url="postgresql://u:p@h:5432/db",
-                    project_name="myproj",
-                )
-
-        mock_phases.assert_called_once_with(
-            "jwt-abc",
-            email="a@b.com",
-            postgres_url="postgresql://u:p@h:5432/db",
-            project_name="myproj",
-            sandbox=False,
-        )
-
-    def test_handles_unauthorized_error(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary"),
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_service.login = AsyncMock(side_effect=ProvablyUnauthorizedError("Bad"))
-
-            _run_login(email="a@b.com", password="bad")  # must not raise
-
-        mock_phases.assert_not_called()
-
-    def test_handles_connection_error(self) -> None:
-        with (
-            patch("sourcerykit.cli.init.questionary"),
-            patch("sourcerykit.cli.init.service") as mock_service,
-            patch("sourcerykit.cli.init._execute_post_auth_phases") as mock_phases,
-            patch("sourcerykit.cli.init.console"),
-        ):
-            mock_service.login = AsyncMock(side_effect=ProvablyConnectionError("Unreachable"))
-
-            _run_login(email="a@b.com", password="pw")  # must not raise
-
-        mock_phases.assert_not_called()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -17,8 +17,8 @@ from sourcerykit.cli.utils import (
     require_settings,
     run_connectivity_check,
 )
+from sourcerykit.provably._auth_api import OAuthTokens
 from sourcerykit.provably._errors import ProvablyConnectionError
-from sourcerykit.provably.oauth_login import OAuthTokens
 
 _VALID_POSTGRES_URL = "postgresql://user:pass@1.2.3.4:5432/mydb"
 
@@ -112,7 +112,7 @@ class TestRunOauthBrowser:
         tokens = OAuthTokens(access_token="at", refresh_token="rt")
         with (
             patch("sourcerykit.cli.init.browser_login", new=AsyncMock(return_value=tokens)),
-            patch("sourcerykit.cli.init.fetch_user_email", new=AsyncMock(return_value="user@example.com")),
+            patch("sourcerykit.cli.init.service.get_user_email", new=AsyncMock(return_value="user@example.com")),
             patch("sourcerykit.cli.init.save_app_dir_config") as mock_save,
             patch("sourcerykit.cli.init._execute_post_auth_phases", return_value=True) as mock_phases,
             patch("sourcerykit.cli.init.console"),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -31,16 +31,16 @@ def _clear_settings_cache() -> Generator[None, None, None]:
 class TestSettings:
     def test_construction_with_all_required_fields(self) -> None:
         s = Settings(
-            api_key="my-key",
+            access_token="my-key",
             org_id=uuid.UUID(_VALID_ORG),
             postgres_url="postgresql://user:pass@localhost/db",
         )
-        assert s.api_key == "my-key"
+        assert s.access_token == "my-key"
         assert s.postgres_url == "postgresql://user:pass@localhost/db"
 
     def test_defaults_for_optional_url_fields(self) -> None:
         s = Settings(
-            api_key="k",
+            access_token="k",
             org_id=uuid.UUID(_VALID_ORG),
             postgres_url="postgresql://x",
         )
@@ -48,31 +48,31 @@ class TestSettings:
         assert s.provably_api == "https://api.provably.ai"
         assert s.provably_mcp == "https://mcp.provably.ai"
 
-    def test_raises_config_error_when_api_key_missing(self) -> None:
-        with pytest.raises(SourceryKitConfigError, match="PROVABLY_API_KEY"):
-            Settings(api_key="", org_id=uuid.UUID(_VALID_ORG))
+    def test_raises_config_error_when_access_token_missing(self) -> None:
+        with pytest.raises(SourceryKitConfigError, match="PROVABLY_ACCESS_TOKEN"):
+            Settings(access_token="", org_id=uuid.UUID(_VALID_ORG))
 
     def test_raises_config_error_when_org_id_is_nil(self) -> None:
         nil_uuid = uuid.UUID(int=0)
         with pytest.raises(SourceryKitConfigError, match="SOURCERYKIT_ORG_ID"):
-            Settings(api_key="k", org_id=nil_uuid)
+            Settings(access_token="k", org_id=nil_uuid)
 
     def test_postgres_url_defaults_to_empty(self) -> None:
-        s = Settings(api_key="k", org_id=uuid.UUID(_VALID_ORG))
+        s = Settings(access_token="k", org_id=uuid.UUID(_VALID_ORG))
         assert s.postgres_url == ""
 
     def test_raises_config_error_lists_all_missing_fields(self) -> None:
         nil = uuid.UUID(int=0)
         with pytest.raises(SourceryKitConfigError) as exc_info:
-            Settings(api_key="", org_id=nil)
+            Settings(access_token="", org_id=nil)
         msg = str(exc_info.value)
-        assert "PROVABLY_API_KEY" in msg
+        assert "PROVABLY_ACCESS_TOKEN" in msg
         assert "SOURCERYKIT_ORG_ID" in msg
 
     def test_is_frozen(self) -> None:
-        s = Settings(api_key="k", org_id=uuid.UUID(_VALID_ORG), postgres_url="postgresql://x")
+        s = Settings(access_token="k", org_id=uuid.UUID(_VALID_ORG), postgres_url="postgresql://x")
         with pytest.raises((AttributeError, TypeError)):
-            s.api_key = "changed"  # type: ignore[misc]
+            s.access_token = "changed"  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -82,16 +82,16 @@ class TestSettings:
 
 class TestGetSettings:
     def test_reads_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("PROVABLY_API_KEY", "env-key")
+        monkeypatch.setenv("PROVABLY_ACCESS_TOKEN", "env-key")
         monkeypatch.setenv("SOURCERYKIT_ORG_ID", _VALID_ORG)
         monkeypatch.setenv("SOURCERYKIT_POSTGRES_URL", "postgresql://env/db")
         s = get_settings()
-        assert s.api_key == "env-key"
+        assert s.access_token == "env-key"
         assert str(s.org_id) == _VALID_ORG
         assert s.postgres_url == "postgresql://env/db"
 
     def test_optional_env_vars_override_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("PROVABLY_API_KEY", "k")
+        monkeypatch.setenv("PROVABLY_ACCESS_TOKEN", "k")
         monkeypatch.setenv("SOURCERYKIT_ORG_ID", _VALID_ORG)
         monkeypatch.setenv("SOURCERYKIT_POSTGRES_URL", "postgresql://x")
         monkeypatch.setenv("SOURCERYKIT_PROVABLY_APP_URL", "https://custom-app.example.com")
@@ -102,7 +102,7 @@ class TestGetSettings:
         from unittest.mock import patch
 
         for key in (
-            "PROVABLY_API_KEY",
+            "PROVABLY_ACCESS_TOKEN",
             "SOURCERYKIT_ORG_ID",
             "SOURCERYKIT_POSTGRES_URL",
             "SOURCERYKIT_PROVABLY_APP_URL",
@@ -118,7 +118,7 @@ class TestGetSettings:
             get_settings()
 
     def test_result_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("PROVABLY_API_KEY", "k")
+        monkeypatch.setenv("PROVABLY_ACCESS_TOKEN", "k")
         monkeypatch.setenv("SOURCERYKIT_ORG_ID", _VALID_ORG)
         monkeypatch.setenv("SOURCERYKIT_POSTGRES_URL", "postgresql://x")
         s1 = get_settings()

--- a/tests/unit/test_config_cli.py
+++ b/tests/unit/test_config_cli.py
@@ -9,7 +9,6 @@ from sourcerykit.cli.config import list as config_list
 def _make_settings(**overrides: object) -> MagicMock:
     """Build a mock Settings with sensible defaults."""
     s = MagicMock()
-    s.api_key = overrides.get("api_key", "zk-12345678-1234-1234-1234-123456789abc")
     s.org_id = overrides.get("org_id", uuid.uuid4())
     s.postgres_url = overrides.get("postgres_url", "postgresql://user:secret@host:5432/db")
     s.project_name = overrides.get("project_name", "my-project")
@@ -17,7 +16,7 @@ def _make_settings(**overrides: object) -> MagicMock:
 
 
 class TestConfigList:
-    def test_shows_masked_key_by_default(self) -> None:
+    def test_shows_org_id(self) -> None:
         s = _make_settings()
         with (
             patch("sourcerykit.cli.config.require_settings", return_value=s),
@@ -25,21 +24,8 @@ class TestConfigList:
         ):
             config_list(show_key=False)
 
-        # Verify console.print was called with masked key
         calls = [str(c) for c in mock_console.print.call_args_list]
-        assert any("****" in c or "***" in c for c in calls)
-
-    def test_shows_full_key_with_show_key(self) -> None:
-        api_key = "zk-12345678-1234-1234-1234-123456789abc"
-        s = _make_settings(api_key=api_key)
-        with (
-            patch("sourcerykit.cli.config.require_settings", return_value=s),
-            patch("sourcerykit.cli.config.console") as mock_console,
-        ):
-            config_list(show_key=True)
-
-        calls = [str(c) for c in mock_console.print.call_args_list]
-        assert any(api_key in c for c in calls)
+        assert any(str(s.org_id) in c for c in calls)
 
     def test_masks_postgres_password(self) -> None:
         s = _make_settings(postgres_url="postgresql://user:secret@host:5432/db")

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -4,10 +4,10 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sourcerykit.cli.doctor import (
-    _check_api_key_and_org,
     _check_bootstrap_ids,
     _check_database,
     _check_project_name,
+    _check_token_and_org,
     _deep_check_collection_and_ids,
     _deep_check_integration,
     _run_deep_check_collection_and_ids,
@@ -18,12 +18,12 @@ from sourcerykit.config import Settings
 from sourcerykit.provably._errors import ProvablyConnectionError, ProvablyUnauthorizedError
 
 _ORG_ID = uuid.uuid4()
-_API_KEY = "zk-12345678-1234-1234-1234-123456789abc"
+_TOKEN = "some-access-token"
 
 
 def _make_settings(
     *,
-    api_key: str = _API_KEY,
+    access_token: str = _TOKEN,
     org_id: uuid.UUID = _ORG_ID,
     postgres_url: str = "postgresql://u:p@host/db",
     project_name: str = "my-project",
@@ -36,7 +36,7 @@ def _make_settings(
 ) -> Settings:
     """Build a real Settings with sensible defaults."""
     return Settings(
-        api_key=api_key,
+        access_token=access_token,
         org_id=org_id,
         postgres_url=postgres_url,
         project_name=project_name,
@@ -62,40 +62,40 @@ def _make_full_settings(**overrides: object) -> Settings:
 
 
 # ---------------------------------------------------------------------------
-# _check_api_key_and_org
+# _check_token_and_org
 # ---------------------------------------------------------------------------
 
 
-class TestCheckApiKeyAndOrg:
-    def test_missing_api_key(self) -> None:
+class TestCheckTokenAndOrg:
+    def test_missing_token(self) -> None:
         s = MagicMock()
-        s.api_key = ""
-        ok, msg = _check_api_key_and_org(s)
+        s.access_token = ""
+        ok, msg = _check_token_and_org(s)
         assert ok is False
-        assert "PROVABLY_API_KEY is missing" in msg
+        assert "Access token is missing" in msg
 
-    def test_valid_key_and_org(self) -> None:
+    def test_valid_token_and_org(self) -> None:
         s = _make_settings()
         orgs = [{"id": str(s.org_id), "name": "My Org"}]
         with patch("sourcerykit.cli.doctor.auth_service") as mock_auth:
             mock_auth.list_organizations = AsyncMock(return_value=orgs)
-            ok, msg = _check_api_key_and_org(s)
+            ok, msg = _check_token_and_org(s)
         assert ok is True
-        assert "API key valid" in msg
+        assert "Session valid" in msg
 
     def test_unauthorized(self) -> None:
         s = _make_settings()
         with patch("sourcerykit.cli.doctor.auth_service") as mock_auth:
             mock_auth.list_organizations = AsyncMock(side_effect=ProvablyUnauthorizedError("bad"))
-            ok, msg = _check_api_key_and_org(s)
+            ok, msg = _check_token_and_org(s)
         assert ok is False
-        assert "invalid or expired" in msg
+        assert "Session expired" in msg
 
     def test_connection_error(self) -> None:
         s = _make_settings()
         with patch("sourcerykit.cli.doctor.auth_service") as mock_auth:
             mock_auth.list_organizations = AsyncMock(side_effect=ProvablyConnectionError("unreachable"))
-            ok, msg = _check_api_key_and_org(s)
+            ok, msg = _check_token_and_org(s)
         assert ok is False
         assert "Cannot reach Provably API" in msg
 
@@ -104,7 +104,7 @@ class TestCheckApiKeyAndOrg:
         orgs = [{"id": str(uuid.uuid4()), "name": "Other Org"}]
         with patch("sourcerykit.cli.doctor.auth_service") as mock_auth:
             mock_auth.list_organizations = AsyncMock(return_value=orgs)
-            ok, msg = _check_api_key_and_org(s)
+            ok, msg = _check_token_and_org(s)
         assert ok is False
         assert "not found" in msg
 
@@ -355,7 +355,7 @@ class TestRunDoctor:
         s = _make_settings()
         with (
             patch("sourcerykit.cli.doctor.get_settings", return_value=s),
-            patch("sourcerykit.cli.doctor._check_api_key_and_org", return_value=(True, "ok")),
+            patch("sourcerykit.cli.doctor._check_token_and_org", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_database", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_project_name", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_bootstrap_ids", return_value=(True, "ok")),
@@ -369,7 +369,7 @@ class TestRunDoctor:
         s = _make_settings()
         with (
             patch("sourcerykit.cli.doctor.get_settings", return_value=s),
-            patch("sourcerykit.cli.doctor._check_api_key_and_org", return_value=(False, "bad key")),
+            patch("sourcerykit.cli.doctor._check_token_and_org", return_value=(False, "bad key")),
             patch("sourcerykit.cli.doctor._check_database", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_project_name", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_bootstrap_ids", return_value=(True, "ok")),
@@ -383,7 +383,7 @@ class TestRunDoctor:
         s = _make_settings()
         with (
             patch("sourcerykit.cli.doctor.get_settings", return_value=s),
-            patch("sourcerykit.cli.doctor._check_api_key_and_org", return_value=(True, "ok")),
+            patch("sourcerykit.cli.doctor._check_token_and_org", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_database", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_project_name", return_value=(True, "ok")),
             patch("sourcerykit.cli.doctor._check_bootstrap_ids", return_value=(False, "missing")),

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -146,35 +146,35 @@ class TestProvablyAuthErrorHandler:
             pass  # must not raise
 
     async def test_http_401_raises_unauthorized_error(self) -> None:
-        mock_request = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/login")
+        mock_request = httpx.Request("GET", "https://api.provably.ai/api/v1/user/current")
         mock_response = httpx.Response(401, request=mock_request, text="Unauthorized")
         http_err = httpx.HTTPStatusError("401", request=mock_request, response=mock_response)
 
         with pytest.raises(ProvablyUnauthorizedError) as exc_info:
-            async with provably_auth_error_handler("login"):
+            async with provably_auth_error_handler("oauth_userinfo"):
                 raise http_err
 
         assert exc_info.value.status_code == 401
-        assert "login" in str(exc_info.value).lower()
+        assert "userinfo" in str(exc_info.value).lower()
 
     async def test_http_400_raises_auth_error(self) -> None:
-        mock_request = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/register")
-        mock_response = httpx.Response(400, request=mock_request, json={"description": "Email already registered"})
+        mock_request = httpx.Request("POST", "https://api.provably.ai/api/v1/organizations")
+        mock_response = httpx.Response(400, request=mock_request, json={"description": "Invalid request"})
         http_err = httpx.HTTPStatusError("400", request=mock_request, response=mock_response)
 
         with pytest.raises(ProvablyAuthError) as exc_info:
-            async with provably_auth_error_handler("create_account"):
+            async with provably_auth_error_handler("create_organization"):
                 raise http_err
 
         assert exc_info.value.status_code == 400
 
     async def test_http_500_raises_auth_error(self) -> None:
-        mock_request = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/login")
+        mock_request = httpx.Request("GET", "https://api.provably.ai/api/v1/user/current")
         mock_response = httpx.Response(500, request=mock_request, text="Internal Server Error")
         http_err = httpx.HTTPStatusError("500", request=mock_request, response=mock_response)
 
         with pytest.raises(ProvablyAuthError) as exc_info:
-            async with provably_auth_error_handler("login"):
+            async with provably_auth_error_handler("oauth_userinfo"):
                 raise http_err
 
         assert exc_info.value.status_code == 500
@@ -206,7 +206,7 @@ class TestProvablyAuthErrorHandler:
                 raise TypeError("cannot convert")
 
     async def test_request_error_raises_connection_error(self) -> None:
-        req = httpx.Request("POST", "https://api.provably.ai/api/v1/auth/login")
+        req = httpx.Request("GET", "https://api.provably.ai/api/v1/user/current")
         with pytest.raises(ProvablyConnectionError):
-            async with provably_auth_error_handler("login"):
+            async with provably_auth_error_handler("oauth_userinfo"):
                 raise httpx.ConnectError("connection refused", request=req)

--- a/tests/unit/test_evaluator_core.py
+++ b/tests/unit/test_evaluator_core.py
@@ -1,7 +1,7 @@
 """Tests for sourcerykit.evaluator.evaluator."""
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -152,10 +152,6 @@ class TestEvaluateHandoff:
             AsyncMock(return_value=verify_result),
         )
         monkeypatch.setattr(
-            "sourcerykit.evaluator.evaluator.get_settings",
-            MagicMock(return_value=MagicMock(api_key="test-key")),
-        )
-        monkeypatch.setattr(
             "sourcerykit.evaluator.evaluator.update_trace",
             AsyncMock(),
         )
@@ -175,10 +171,6 @@ class TestEvaluateHandoff:
         monkeypatch.setattr(
             "sourcerykit.evaluator.evaluator.service.verify_proof",
             AsyncMock(return_value=None),
-        )
-        monkeypatch.setattr(
-            "sourcerykit.evaluator.evaluator.get_settings",
-            MagicMock(return_value=MagicMock(api_key="test-key")),
         )
 
         result = await evaluate_handoff(payload=payload)
@@ -201,10 +193,6 @@ class TestEvaluateHandoff:
             AsyncMock(side_effect=RuntimeError("proof failed")),
         )
         monkeypatch.setattr(
-            "sourcerykit.evaluator.evaluator.get_settings",
-            MagicMock(return_value=MagicMock(api_key="test-key")),
-        )
-        monkeypatch.setattr(
             "sourcerykit.evaluator.evaluator.update_trace",
             AsyncMock(),
         )
@@ -219,10 +207,6 @@ class TestEvaluateHandoff:
         monkeypatch.setattr(
             "sourcerykit.evaluator.evaluator.verify_claim_endpoints",
             AsyncMock(return_value=None),
-        )
-        monkeypatch.setattr(
-            "sourcerykit.evaluator.evaluator.get_settings",
-            MagicMock(return_value=MagicMock(api_key="test-key")),
         )
 
         result = await evaluate_handoff(payload=payload)

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -125,3 +125,46 @@ class TestProvablyHTTPClientPreAuth:
             await client.get("/api/v1/user/key", token="my-jwt-token")
             _, kwargs = mock_req.call_args
             assert kwargs.get("token") == "my-jwt-token"
+
+
+class TestProvablyHTTPClientOAuthRefresh:
+    def _make_401(self) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 401
+        resp.text = "expired"
+        req = httpx.Request("GET", "http://x")
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError("401", request=req, response=resp)
+        return resp
+
+    def _make_ok(self) -> MagicMock:
+        resp = MagicMock()
+        resp.content = b'{"ok": true}'
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"ok": True}
+        return resp
+
+    async def test_401_refreshes_once_and_retries(self) -> None:
+        client = _make_client()
+        calls = 0
+
+        async def fake_request(method: str, path: str, **kwargs: object) -> MagicMock:
+            nonlocal calls
+            calls += 1
+            return self._make_ok() if calls > 1 else self._make_401()
+
+        client._request = fake_request  # type: ignore[method-assign]
+
+        with patch("sourcerykit.provably._http._refresh_session", AsyncMock(return_value="new-token")) as refresh:
+            result = await client.get("/api/v1/data", token="old-token")
+
+        assert result == {"ok": True}
+        refresh.assert_awaited_once()
+        assert calls == 2
+
+    async def test_401_without_refresh_token_raises(self) -> None:
+        client = _make_client()
+        client._request = AsyncMock(return_value=self._make_401())  # type: ignore[method-assign]
+
+        with patch("sourcerykit.provably._http._refresh_session", AsyncMock(return_value=None)):
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.get("/api/v1/data", token="old-token")

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,21 +1,40 @@
 """Tests for sourcerykit.provably._http.ProvablyHTTPClient."""
 
+import os
+from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from sourcerykit.config import Settings
-from sourcerykit.provably._http import ProvablyHTTPClient
+from sourcerykit.provably._http import ProvablyHTTPClient, _clear_refresh_token, _persist_tokens
 
 _ORG = "00000000-0000-0000-0000-000000000001"
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Provide env so _fetch's default Bearer resolution (get_settings) succeeds."""
+    from sourcerykit.config import get_settings, load_app_dir_config, load_local_env
+
+    get_settings.cache_clear()
+    load_app_dir_config.cache_clear()
+    load_local_env.cache_clear()
+    monkeypatch.setenv("PROVABLY_ACCESS_TOKEN", "test-access-token")
+    monkeypatch.setenv("SOURCERYKIT_ORG_ID", _ORG)
+    yield
+    get_settings.cache_clear()
+    load_app_dir_config.cache_clear()
+    load_local_env.cache_clear()
 
 
 def _make_settings(api_url: str = "https://api.provably.ai") -> Settings:
     import uuid
 
     return Settings(
-        api_key="test-api-key",
+        access_token="test-access-token",
         org_id=uuid.UUID(_ORG),
         postgres_url="postgresql://user:pass@localhost/db",
         provably_api=api_url,
@@ -31,9 +50,10 @@ class TestProvablyHTTPClientInit:
         client = _make_client("https://api.provably.ai/")
         assert client.base_url == "https://api.provably.ai"
 
-    def test_headers_include_api_key(self) -> None:
+    def test_headers_do_not_include_auth(self) -> None:
         client = _make_client()
-        assert client._headers["x-api-key"] == "test-api-key"
+        assert "x-api-key" not in client._headers
+        assert "Authorization" not in client._headers
 
     def test_headers_include_content_type(self) -> None:
         client = _make_client()
@@ -74,6 +94,41 @@ class TestProvablyHTTPClientGet:
             await client.get("/path", params={"key": "val"})
             _, kwargs = mock_req.call_args
             assert kwargs.get("params") == {"key": "val"}
+
+
+class TestProvablyHTTPClientAuth:
+    async def test_post_auth_injects_access_token_as_bearer(self) -> None:
+        client = _make_client()
+        mock_response = MagicMock()
+        mock_response.content = b'{"result": "ok"}'
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"result": "ok"}
+
+        with (
+            patch("sourcerykit.provably._http.get_settings", return_value=_make_settings()),
+            patch.object(client, "_request", AsyncMock(return_value=mock_response)) as mock_req,
+        ):
+            await client.get("/path")
+
+        _, kwargs = mock_req.call_args
+        assert kwargs.get("token") == "test-access-token"
+
+    async def test_api_key_override_suppresses_bearer(self) -> None:
+        client = _make_client()
+        mock_response = MagicMock()
+        mock_response.content = b'{"ok": true}'
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+
+        with (
+            patch("sourcerykit.provably._http.get_settings", return_value=_make_settings()),
+            patch.object(client, "_request", AsyncMock(return_value=mock_response)) as mock_req,
+        ):
+            await client.get("/path", api_key="i-zk-123")
+
+        _, kwargs = mock_req.call_args
+        assert kwargs.get("api_key") == "i-zk-123"
+        assert kwargs.get("token") is None
 
 
 class TestProvablyHTTPClientPost:
@@ -125,6 +180,45 @@ class TestProvablyHTTPClientPreAuth:
             await client.get("/api/v1/user/key", token="my-jwt-token")
             _, kwargs = mock_req.call_args
             assert kwargs.get("token") == "my-jwt-token"
+
+
+class TestTokenStorePersistence:
+    def test_persist_tokens_writes_to_app_store_and_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        store = tmp_path / "app.env"
+        monkeypatch.setenv("SOURCERYKIT_TOKEN_STORE", str(store))
+
+        with (
+            patch("sourcerykit.provably._http.get_settings") as mock_gs,
+            patch("sourcerykit.provably._http.load_local_env") as mock_lle,
+            patch("sourcerykit.provably._http.save_app_dir_config") as mock_save,
+        ):
+            _persist_tokens("at2", "rt2")
+
+        mock_save.assert_not_called()
+        assert os.environ["PROVABLY_ACCESS_TOKEN"] == "at2"
+        assert os.environ["PROVABLY_REFRESH_TOKEN"] == "rt2"
+        content = store.read_text()
+        assert "PROVABLY_ACCESS_TOKEN" in content and "at2" in content
+        assert "PROVABLY_REFRESH_TOKEN" in content and "rt2" in content
+        mock_lle.cache_clear.assert_called_once()
+        mock_gs.cache_clear.assert_called_once()
+
+    def test_persist_tokens_uses_global_json_when_no_store(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SOURCERYKIT_TOKEN_STORE", raising=False)
+        with patch("sourcerykit.provably._http.save_app_dir_config") as mock_save:
+            _persist_tokens("at", None)
+        mock_save.assert_called_once_with(token="at", refresh_token=None)
+
+    def test_clear_refresh_token_from_app_store(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        store = tmp_path / "app.env"
+        monkeypatch.setenv("SOURCERYKIT_TOKEN_STORE", str(store))
+        store.write_text("PROVABLY_REFRESH_TOKEN=rt\n")
+        os.environ["PROVABLY_REFRESH_TOKEN"] = "rt"
+
+        _clear_refresh_token()
+
+        assert "PROVABLY_REFRESH_TOKEN" not in os.environ
+        assert "PROVABLY_REFRESH_TOKEN=" in store.read_text()
 
 
 class TestProvablyHTTPClientOAuthRefresh:

--- a/tests/unit/test_oauth_login.py
+++ b/tests/unit/test_oauth_login.py
@@ -2,13 +2,7 @@
 
 import base64
 import hashlib
-from collections.abc import Callable
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
-
-from sourcerykit.provably import oauth_login
 from sourcerykit.provably.oauth_login import pkce_pair
 
 
@@ -17,54 +11,3 @@ def test_pkce_pair_s256_verifiable() -> None:
     assert verifier and challenge
     expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
     assert challenge == expected
-
-
-def _json_response(status: int, payload: dict[str, object]) -> httpx.Response:
-    return httpx.Response(status, json=payload, request=httpx.Request("GET", "http://test"))
-
-
-def _mock_client(fake_request: Callable[..., Any]) -> MagicMock:
-    client = MagicMock(spec=httpx.AsyncClient)
-    client.request = fake_request
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
-    return client
-
-
-class TestFetchUserEmail:
-    async def test_returns_top_level_email(self) -> None:
-        async def fake_request(method: str, url: str, **kwargs: object) -> httpx.Response:
-            assert method == "GET"
-            assert "/api/v1/user/current" in url
-            assert kwargs["headers"]["Authorization"] == "Bearer at"  # type: ignore[index]
-            return _json_response(200, {"email": "a@b.com"})
-
-        with patch("sourcerykit.provably.oauth_login.httpx.AsyncClient", return_value=_mock_client(fake_request)):
-            assert await oauth_login.fetch_user_email("at") == "a@b.com"
-
-    async def test_missing_email_raises(self) -> None:
-        async def fake_request(method: str, url: str, **kwargs: object) -> httpx.Response:
-            return _json_response(200, {"name": "no email"})
-
-        with patch("sourcerykit.provably.oauth_login.httpx.AsyncClient", return_value=_mock_client(fake_request)):
-            try:
-                await oauth_login.fetch_user_email("at")
-            except ValueError as e:
-                assert "email" in str(e)
-                return
-        raise AssertionError("expected ValueError for missing email")
-
-
-class TestRefresh:
-    async def test_refresh_tokens_rotates(self) -> None:
-        tokens = _json_response(200, {"access_token": "new-at", "refresh_token": "new-rt"})
-
-        async def fake_request(method: str, url: str, **kwargs: object) -> httpx.Response:
-            assert "oauth/refresh" in url
-            return tokens
-
-        with patch("sourcerykit.provably.oauth_login.httpx.AsyncClient", return_value=_mock_client(fake_request)):
-            result = await oauth_login.refresh_tokens("old-rt")
-
-        assert result.access_token == "new-at"
-        assert result.refresh_token == "new-rt"

--- a/tests/unit/test_oauth_login.py
+++ b/tests/unit/test_oauth_login.py
@@ -1,0 +1,70 @@
+"""Tests for sourcerykit.provably.oauth_login."""
+
+import base64
+import hashlib
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from sourcerykit.provably import oauth_login
+from sourcerykit.provably.oauth_login import pkce_pair
+
+
+def test_pkce_pair_s256_verifiable() -> None:
+    verifier, challenge = pkce_pair()
+    assert verifier and challenge
+    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    assert challenge == expected
+
+
+def _json_response(status: int, payload: dict[str, object]) -> httpx.Response:
+    return httpx.Response(status, json=payload, request=httpx.Request("GET", "http://test"))
+
+
+def _mock_client(fake_request: Callable[..., Any]) -> MagicMock:
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.request = fake_request
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+class TestFetchUserEmail:
+    async def test_returns_top_level_email(self) -> None:
+        async def fake_request(method: str, url: str, **kwargs: object) -> httpx.Response:
+            assert method == "GET"
+            assert "/api/v1/user/current" in url
+            assert kwargs["headers"]["Authorization"] == "Bearer at"  # type: ignore[index]
+            return _json_response(200, {"email": "a@b.com"})
+
+        with patch("sourcerykit.provably.oauth_login.httpx.AsyncClient", return_value=_mock_client(fake_request)):
+            assert await oauth_login.fetch_user_email("at") == "a@b.com"
+
+    async def test_missing_email_raises(self) -> None:
+        async def fake_request(method: str, url: str, **kwargs: object) -> httpx.Response:
+            return _json_response(200, {"name": "no email"})
+
+        with patch("sourcerykit.provably.oauth_login.httpx.AsyncClient", return_value=_mock_client(fake_request)):
+            try:
+                await oauth_login.fetch_user_email("at")
+            except ValueError as e:
+                assert "email" in str(e)
+                return
+        raise AssertionError("expected ValueError for missing email")
+
+
+class TestRefresh:
+    async def test_refresh_tokens_rotates(self) -> None:
+        tokens = _json_response(200, {"access_token": "new-at", "refresh_token": "new-rt"})
+
+        async def fake_request(method: str, url: str, **kwargs: object) -> httpx.Response:
+            assert "oauth/refresh" in url
+            return tokens
+
+        with patch("sourcerykit.provably.oauth_login.httpx.AsyncClient", return_value=_mock_client(fake_request)):
+            result = await oauth_login.refresh_tokens("old-rt")
+
+        assert result.access_token == "new-at"
+        assert result.refresh_token == "new-rt"

--- a/tests/unit/test_payload_builder.py
+++ b/tests/unit/test_payload_builder.py
@@ -39,7 +39,7 @@ def _env(monkeypatch: pytest.MonkeyPatch) -> None:
     get_settings.cache_clear()
     load_app_dir_config.cache_clear()
     load_local_env.cache_clear()
-    monkeypatch.setenv("PROVABLY_API_KEY", "k")
+    monkeypatch.setenv("PROVABLY_ACCESS_TOKEN", "k")
     monkeypatch.setenv("SOURCERYKIT_ORG_ID", str(_ORG))
     monkeypatch.setenv("SOURCERYKIT_POSTGRES_URL", "postgresql://x")
     monkeypatch.setenv("SOURCERYKIT_PROVABLY_MCP_URL", "https://mcp.example.com")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from sourcerykit.provably._errors import ProvablyAPIError, ProvablyConnectionError
+from sourcerykit.provably._errors import ProvablyAPIError, ProvablyDataError
 from sourcerykit.provably.service import ProvablyService
 
 
@@ -100,42 +100,30 @@ class TestProvablyServiceListCollections:
 
 
 # ---------------------------------------------------------------------------
-# get_integration_by_id
+# ensure_integration
 # ---------------------------------------------------------------------------
 
 
-class TestProvablyServiceGetIntegrationById:
-    async def test_returns_record(self) -> None:
+class TestProvablyServiceEnsureIntegration:
+    async def test_returns_id_and_key(self) -> None:
         service, mock_api = _make_service()
+        collection_id = uuid.uuid4()
         integration_id = uuid.uuid4()
-        record = {"id": str(integration_id), "name": "my-integration", "api_key": "key-123"}
-        mock_api.get_integration_by_id = AsyncMock(return_value=record)
-
-        with patch("sourcerykit.provably.service.get_api", return_value=mock_api):
-            result = await service.get_integration_by_id(integration_id)
-
-        assert result == record
-        mock_api.get_integration_by_id.assert_called_once_with(integration_id)
-
-    async def test_api_error(self) -> None:
-        service, mock_api = _make_service()
-        integration_id = uuid.uuid4()
-        mock_request = httpx.Request("GET", f"https://api.provably.ai/api/v1/integrations/{integration_id}")
-        mock_response = httpx.Response(404, request=mock_request, text="Not Found")
-        mock_api.get_integration_by_id = AsyncMock(
-            side_effect=httpx.HTTPStatusError("404", request=mock_request, response=mock_response)
+        mock_api.ensure_integration = AsyncMock(
+            return_value={"id": str(integration_id), "api_key": "i-zk-key-123", "collections": [str(collection_id)]}
         )
 
         with patch("sourcerykit.provably.service.get_api", return_value=mock_api):
-            with pytest.raises(ProvablyAPIError):
-                await service.get_integration_by_id(integration_id)
+            result = await service.ensure_integration(collection_id)
 
-    async def test_connection_error(self) -> None:
+        assert result == (integration_id, "i-zk-key-123")
+        call_body = mock_api.ensure_integration.call_args.args[0]
+        assert call_body["collections"] == [str(collection_id)]
+
+    async def test_missing_key_raises_data_error(self) -> None:
         service, mock_api = _make_service()
-        integration_id = uuid.uuid4()
-        mock_request = httpx.Request("GET", f"https://api.provably.ai/api/v1/integrations/{integration_id}")
-        mock_api.get_integration_by_id = AsyncMock(side_effect=httpx.ConnectError("unreachable", request=mock_request))
+        mock_api.ensure_integration = AsyncMock(return_value={"id": str(uuid.uuid4())})
 
         with patch("sourcerykit.provably.service.get_api", return_value=mock_api):
-            with pytest.raises(ProvablyConnectionError):
-                await service.get_integration_by_id(integration_id)
+            with pytest.raises(ProvablyDataError):
+                await service.ensure_integration(uuid.uuid4())


### PR DESCRIPTION
This pr migrates authentication to OAuth and makes integration bootstrap idempotent. Existing users must re-run sourcerykit init.

## Key Changes
### Breaking changes
- **User API key removed in favor of OAuth tokens** — authentication now uses `PROVABLY_ACCESS_TOKEN` (auto-refreshed via `PROVABLY_REFRESH_TOKEN`); the verify path uses the collection integration key. Existing users must re-run `sourcerykit init`. See the [migration guide](docs/migrations/unreleased/unreleased.md).
- **OAuth browser-only login** — `--register`, `--email`, and `--password` are removed; login is browser OAuth (PKCE) only. New accounts are created on the Provably web app during login.

### Features
- **Idempotent integration bootstrap** — re-running `init`/`doctor --fix` reuses the existing integration (exact collection match) instead of minting a duplicate key and shadow user.